### PR TITLE
Make errors faithful

### DIFF
--- a/v2_keys.go
+++ b/v2_keys.go
@@ -17,9 +17,8 @@ type V2AsymmetricPublicKey struct {
 func NewV2AsymmetricPublicKeyFromHex(hexEncoded string) (V2AsymmetricPublicKey, error) {
 	publicKey, err := hex.DecodeString(hexEncoded)
 	if err != nil {
-		// even though we return error, return a random key here rather than
-		// a nil key
-		return NewV2AsymmetricSecretKey().Public(), err
+
+		return V2AsymmetricPublicKey{}, err
 	}
 
 	return NewV2AsymmetricPublicKeyFromBytes(publicKey)
@@ -28,9 +27,8 @@ func NewV2AsymmetricPublicKeyFromHex(hexEncoded string) (V2AsymmetricPublicKey, 
 // NewV2AsymmetricPublicKeyFromBytes Construct a v2 public key from bytes
 func NewV2AsymmetricPublicKeyFromBytes(publicKey []byte) (V2AsymmetricPublicKey, error) {
 	if len(publicKey) != 32 {
-		// even though we return error, return a random key here rather than
-		// a nil key
-		return NewV2AsymmetricSecretKey().Public(), errors.New("Key incorrect length")
+
+		return V2AsymmetricPublicKey{}, errors.New("Key incorrect length")
 	}
 
 	return V2AsymmetricPublicKey{publicKey}, nil
@@ -95,9 +93,8 @@ func NewV2AsymmetricSecretKeyFromHex(hexEncoded string) (V2AsymmetricSecretKey, 
 	privateKey, err := hex.DecodeString(hexEncoded)
 
 	if err != nil {
-		// even though we return error, return a random key here rather than
-		// a nil key
-		return NewV2AsymmetricSecretKey(), err
+
+		return V2AsymmetricSecretKey{}, err
 	}
 
 	return NewV2AsymmetricSecretKeyFromBytes(privateKey)
@@ -106,9 +103,8 @@ func NewV2AsymmetricSecretKeyFromHex(hexEncoded string) (V2AsymmetricSecretKey, 
 // NewV2AsymmetricSecretKeyFromBytes creates a secret key from bytes
 func NewV2AsymmetricSecretKeyFromBytes(privateKey []byte) (V2AsymmetricSecretKey, error) {
 	if len(privateKey) != 64 {
-		// even though we return error, return a random key here rather than
-		// a nil key
-		return NewV2AsymmetricSecretKey(), errors.New("Key incorrect length")
+
+		return V2AsymmetricSecretKey{}, errors.New("Key incorrect length")
 	}
 
 	return V2AsymmetricSecretKey{privateKey}, nil
@@ -119,15 +115,13 @@ func NewV2AsymmetricSecretKeyFromSeed(hexEncoded string) (V2AsymmetricSecretKey,
 	seedBytes, err := hex.DecodeString(hexEncoded)
 
 	if err != nil {
-		// even though we return error, return a random key here rather than
-		// a nil key
-		return NewV2AsymmetricSecretKey(), err
+
+		return V2AsymmetricSecretKey{}, err
 	}
 
 	if len(seedBytes) != 32 {
-		// even though we return error, return a random key here rather than
-		// a nil key
-		return NewV2AsymmetricSecretKey(), errors.New("Key incorrect length")
+
+		return V2AsymmetricSecretKey{}, errors.New("Key incorrect length")
 	}
 
 	return V2AsymmetricSecretKey{ed25519.NewKeyFromSeed(seedBytes)}, nil
@@ -160,9 +154,8 @@ func (k V2SymmetricKey) ExportBytes() []byte {
 func V2SymmetricKeyFromHex(hexEncoded string) (V2SymmetricKey, error) {
 	bytes, err := hex.DecodeString(hexEncoded)
 	if err != nil {
-		// even though we return error, return a random key here rather than
-		// a nil key
-		return NewV2SymmetricKey(), err
+
+		return V2SymmetricKey{}, err
 	}
 
 	return V2SymmetricKeyFromBytes(bytes)
@@ -171,9 +164,8 @@ func V2SymmetricKeyFromHex(hexEncoded string) (V2SymmetricKey, error) {
 // V2SymmetricKeyFromBytes constructs a key from bytes
 func V2SymmetricKeyFromBytes(bytes []byte) (V2SymmetricKey, error) {
 	if len(bytes) != 32 {
-		// even though we return error, return a random key here rather than
-		// a nil key
-		return NewV2SymmetricKey(), errors.New("Key incorrect length")
+
+		return V2SymmetricKey{}, errors.New("Key incorrect length")
 	}
 
 	var material [32]byte

--- a/v3_keys.go
+++ b/v3_keys.go
@@ -24,9 +24,8 @@ func NewV3AsymmetricPublicKeyFromHex(hexEncoded string) (V3AsymmetricPublicKey, 
 	publicKeyBytes, err := hex.DecodeString(hexEncoded)
 
 	if err != nil {
-		// even though we return error, return a random key here rather than
-		// a nil key
-		return NewV3AsymmetricSecretKey().Public(), err
+
+		return V3AsymmetricPublicKey{}, err
 	}
 
 	return NewV3AsymmetricPublicKeyFromBytes(publicKeyBytes)
@@ -35,9 +34,8 @@ func NewV3AsymmetricPublicKeyFromHex(hexEncoded string) (V3AsymmetricPublicKey, 
 // NewV3AsymmetricPublicKeyFromBytes Construct a v3 public key from bytes
 func NewV3AsymmetricPublicKeyFromBytes(publicKeyBytes []byte) (V3AsymmetricPublicKey, error) {
 	if len(publicKeyBytes) != 49 {
-		// even though we return error, return a random key here rather than
-		// a nil key
-		return NewV3AsymmetricSecretKey().Public(), errors.New("Key incorrect length")
+
+		return V3AsymmetricPublicKey{}, errors.New("Key incorrect length")
 	}
 
 	publicKey := new(ecdsa.PublicKey)
@@ -99,9 +97,8 @@ func NewV3AsymmetricSecretKeyFromHex(hexEncoded string) (V3AsymmetricSecretKey, 
 	secretBytes, err := hex.DecodeString(hexEncoded)
 
 	if err != nil {
-		// even though we return error, return a random key here rather than
-		// a nil key
-		return NewV3AsymmetricSecretKey(), err
+
+		return V3AsymmetricSecretKey{}, err
 	}
 
 	return NewV3AsymmetricSecretKeyFromBytes(secretBytes)
@@ -110,9 +107,8 @@ func NewV3AsymmetricSecretKeyFromHex(hexEncoded string) (V3AsymmetricSecretKey, 
 // NewV3AsymmetricSecretKeyFromBytes creates a secret key from bytes
 func NewV3AsymmetricSecretKeyFromBytes(secretBytes []byte) (V3AsymmetricSecretKey, error) {
 	if len(secretBytes) != 48 {
-		// even though we return error, return a random key here rather than
-		// a nil key
-		return NewV3AsymmetricSecretKey(), errors.New("Key incorrect length")
+
+		return V3AsymmetricSecretKey{}, errors.New("Key incorrect length")
 	}
 
 	privateKey := new(ecdsa.PrivateKey)
@@ -154,9 +150,8 @@ func (k V3SymmetricKey) ExportBytes() []byte {
 func V3SymmetricKeyFromHex(hexEncoded string) (V3SymmetricKey, error) {
 	bytes, err := hex.DecodeString(hexEncoded)
 	if err != nil {
-		// even though we return error, return a random key here rather than
-		// a nil key
-		return NewV3SymmetricKey(), err
+
+		return V3SymmetricKey{}, err
 	}
 
 	return V3SymmetricKeyFromBytes(bytes)
@@ -165,9 +160,8 @@ func V3SymmetricKeyFromHex(hexEncoded string) (V3SymmetricKey, error) {
 // V3SymmetricKeyFromBytes constructs a key from bytes
 func V3SymmetricKeyFromBytes(bytes []byte) (V3SymmetricKey, error) {
 	if len(bytes) != 32 {
-		// even though we return error, return a random key here rather than
-		// a nil key
-		return NewV3SymmetricKey(), errors.New("Key incorrect length")
+
+		return V3SymmetricKey{}, errors.New("Key incorrect length")
 	}
 
 	var material [32]byte

--- a/v4_keys.go
+++ b/v4_keys.go
@@ -19,9 +19,8 @@ func NewV4AsymmetricPublicKeyFromHex(hexEncoded string) (V4AsymmetricPublicKey, 
 	publicKey, err := hex.DecodeString(hexEncoded)
 
 	if err != nil {
-		// even though we return error, return a random key here rather than
-		// a nil key
-		return NewV4AsymmetricSecretKey().Public(), err
+
+		return V4AsymmetricPublicKey{}, err
 	}
 
 	return NewV4AsymmetricPublicKeyFromBytes(publicKey)
@@ -30,9 +29,8 @@ func NewV4AsymmetricPublicKeyFromHex(hexEncoded string) (V4AsymmetricPublicKey, 
 // NewV4AsymmetricPublicKeyFromBytes Construct a v4 public key from bytes
 func NewV4AsymmetricPublicKeyFromBytes(publicKey []byte) (V4AsymmetricPublicKey, error) {
 	if len(publicKey) != 32 {
-		// even though we return error, return a random key here rather than
-		// a nil key
-		return NewV4AsymmetricSecretKey().Public(), errors.New("Key incorrect length")
+
+		return V4AsymmetricPublicKey{}, errors.New("Key incorrect length")
 	}
 
 	return V4AsymmetricPublicKey{publicKey}, nil
@@ -97,9 +95,8 @@ func NewV4AsymmetricSecretKeyFromHex(hexEncoded string) (V4AsymmetricSecretKey, 
 	privateKey, err := hex.DecodeString(hexEncoded)
 
 	if err != nil {
-		// even though we return error, return a random key here rather than
-		// a nil key
-		return NewV4AsymmetricSecretKey(), err
+
+		return V4AsymmetricSecretKey{}, err
 	}
 
 	return NewV4AsymmetricSecretKeyFromBytes(privateKey)
@@ -108,9 +105,8 @@ func NewV4AsymmetricSecretKeyFromHex(hexEncoded string) (V4AsymmetricSecretKey, 
 // NewV4AsymmetricSecretKeyFromBytes creates a secret key from bytes
 func NewV4AsymmetricSecretKeyFromBytes(privateKey []byte) (V4AsymmetricSecretKey, error) {
 	if len(privateKey) != 64 {
-		// even though we return error, return a random key here rather than
-		// a nil key
-		return NewV4AsymmetricSecretKey(), errors.New("Key incorrect length")
+
+		return V4AsymmetricSecretKey{}, errors.New("Key incorrect length")
 	}
 
 	return V4AsymmetricSecretKey{privateKey}, nil
@@ -121,15 +117,13 @@ func NewV4AsymmetricSecretKeyFromSeed(hexEncoded string) (V4AsymmetricSecretKey,
 	seedBytes, err := hex.DecodeString(hexEncoded)
 
 	if err != nil {
-		// even though we return error, return a random key here rather than
-		// a nil key
-		return NewV4AsymmetricSecretKey(), err
+
+		return V4AsymmetricSecretKey{}, err
 	}
 
 	if len(seedBytes) != 32 {
-		// even though we return error, return a random key here rather than
-		// a nil key
-		return NewV4AsymmetricSecretKey(), errors.New("Key incorrect length")
+
+		return V4AsymmetricSecretKey{}, errors.New("Key incorrect length")
 	}
 
 	return V4AsymmetricSecretKey{ed25519.NewKeyFromSeed(seedBytes)}, nil
@@ -163,9 +157,8 @@ func V4SymmetricKeyFromHex(hexEncoded string) (V4SymmetricKey, error) {
 	bytes, err := hex.DecodeString(hexEncoded)
 
 	if err != nil {
-		// even though we return error, return a random key here rather than
-		// a nil key
-		return NewV4SymmetricKey(), err
+
+		return V4SymmetricKey{}, err
 	}
 
 	return V4SymmetricKeyFromBytes(bytes)
@@ -174,9 +167,8 @@ func V4SymmetricKeyFromHex(hexEncoded string) (V4SymmetricKey, error) {
 // V4SymmetricKeyFromBytes constructs a key from bytes
 func V4SymmetricKeyFromBytes(bytes []byte) (V4SymmetricKey, error) {
 	if len(bytes) != 32 {
-		// even though we return error, return a random key here rather than
-		// a nil key
-		return NewV4SymmetricKey(), errors.New("Key incorrect length")
+
+		return V4SymmetricKey{}, errors.New("Key incorrect length")
 	}
 
 	var material [32]byte


### PR DESCRIPTION
Just leaving this here as a conversation starter.

I might not be aware of all details, but, is there any particular reason to compute new keys even though they must not be used?
Since an error is returned, is there a case where use of randomly generated keys would make sense?

I just stumbled upon this as I tried to build a v4 key pair from bytes coming from a x25519 pem certificate.
I had some invisible character slip into the certificate string due to automatic code formatting, so the byte slice representing the key was off, yet I was obtaining a fully functional key.
