### PR TITLE
Raise min permitted version of Go to 1.18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-on: 
+on:
   push:
     branches:
       - main
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: [1.16.x, 1.17.x, 1.18.x, 1.19.x]
+        go: [1.18.x, 1.19.x, 1.20.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module aidanwoods.dev/go-paseto
 
-go 1.17
+go 1.18
 
 require (
 	github.com/stretchr/testify v1.7.0


### PR DESCRIPTION
1.18 is just about EOL, but I'll keep it permitted for the time being.