### PR TITLE
Add support for custom token types through generics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: [1.18.x, 1.19.x, 1.20.x]
+        go: [1.21.x, 1.22.x, 1.23.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/claims.go
+++ b/claims.go
@@ -13,37 +13,30 @@ type Rule[T any] func(token T) error
 
 type TokenAudience interface {
 	GetAudience() (string, error)
-	// SetAudience(string)
 }
 
 type TokenExpiration interface {
 	GetExpiration() (time.Time, error)
-	// SetExpiration(time.Time)
 }
 
 type TokenIssuedAt interface {
 	GetIssuedAt() (time.Time, error)
-	// SetIssuedAt(time.Time)
 }
 
 type TokenIssuer interface {
 	GetIssuer() (string, error)
-	// SetIssuer(string)
 }
 
 type TokenJti interface {
 	GetJti() (string, error)
-	// SetJti(string)
 }
 
 type TokenNotBefore interface {
 	GetNotBefore() (time.Time, error)
-	// SetNotBefore(string)
 }
 
 type TokenSubject interface {
 	GetSubject() (string, error)
-	// SetSubject(string)
 }
 
 // ForAudienceT requires that the given audience matches the audience field of the

--- a/claims.go
+++ b/claims.go
@@ -9,12 +9,47 @@ import (
 // Rule validates a given token for certain required preconditions (defined by
 // the rule itself). If validation fails a Rule MUST return an error, otherwise
 // error MUST be nil.
-type Rule func(token Token) error
+type Rule[T any] func(token T) error
 
-// ForAudience requires that the given audience matches the "aud" field of the
+type TokenAudience interface {
+	GetAudience() (string, error)
+	// SetAudience(string)
+}
+
+type TokenExpiration interface {
+	GetExpiration() (time.Time, error)
+	// SetExpiration(time.Time)
+}
+
+type TokenIssuedAt interface {
+	GetIssuedAt() (time.Time, error)
+	// SetIssuedAt(time.Time)
+}
+
+type TokenIssuer interface {
+	GetIssuer() (string, error)
+	// SetIssuer(string)
+}
+
+type TokenJti interface {
+	GetJti() (string, error)
+	// SetJti(string)
+}
+
+type TokenNotBefore interface {
+	GetNotBefore() (time.Time, error)
+	// SetNotBefore(string)
+}
+
+type TokenSubject interface {
+	GetSubject() (string, error)
+	// SetSubject(string)
+}
+
+// ForAudienceT requires that the given audience matches the audience field of the
 // token.
-func ForAudience(audience string) Rule {
-	return func(token Token) error {
+func ForAudienceT[T TokenAudience](audience string) Rule[T] {
+	return func(token T) error {
 		tAud, err := token.GetAudience()
 		if err != nil {
 			return err
@@ -28,10 +63,14 @@ func ForAudience(audience string) Rule {
 	}
 }
 
-// IdentifiedBy requires that the given identifier matches the "jti" field of
+// ForAudience requires that the given audience matches the "aud" field of the
+// token.
+var ForAudience = ForAudienceT[Token]
+
+// IdentifiedByT requires that the given identifier matches the jti field of
 // the token.
-func IdentifiedBy(identifier string) Rule {
-	return func(token Token) error {
+func IdentifiedByT[T TokenJti](identifier string) Rule[T] {
+	return func(token T) error {
 		tJti, err := token.GetJti()
 		if err != nil {
 			return err
@@ -45,9 +84,13 @@ func IdentifiedBy(identifier string) Rule {
 	}
 }
 
-// IssuedBy requires that the given issuer matches the "iss" field of the token.
-func IssuedBy(issuer string) Rule {
-	return func(token Token) error {
+// IdentifiedBy requires that the given identifier matches the "jti" field of
+// the token.
+var IdentifiedBy = IdentifiedByT[Token]
+
+// IssuedByT requires that the given issuer matches the issuer field of the token.
+func IssuedByT[T TokenIssuer](issuer string) Rule[T] {
+	return func(token T) error {
 		tIss, err := token.GetIssuer()
 		if err != nil {
 			return err
@@ -64,12 +107,15 @@ func IssuedBy(issuer string) Rule {
 	}
 }
 
-// NotBeforeNbf requires that the token is allowed to be used according to the time
-// when this rule is checked and the "nbf" field of a token. Beware that this
-// rule does not validate the token's "iat" or "exp" fields, or even require
+// IssuedBy requires that the given issuer matches the "iss" field of the token.
+var IssuedBy = IssuedByT[Token]
+
+// NotBeforeNbfT requires that the token is allowed to be used according to the time
+// when this rule is checked and the not before field of a token. Beware that this
+// rule does not validate the token's issued at or expiration fields, or even require
 // their presence.
-func NotBeforeNbf() Rule {
-	return func(token Token) error {
+func NotBeforeNbfT[T TokenNotBefore]() Rule[T] {
+	return func(token T) error {
 		nbf, err := token.GetNotBefore()
 		if err != nil {
 			return err
@@ -83,12 +129,18 @@ func NotBeforeNbf() Rule {
 	}
 }
 
-// NotExpired requires that the token has not expired according to the time
-// when this rule is checked and the "exp" field of a token. Beware that this
-// rule does not validate the token's "iat" or "nbf" fields, or even require
+// NotBeforeNbf requires that the token is allowed to be used according to the time
+// when this rule is checked and the not before field of a token. Beware that this
+// rule does not validate the token's issued at or expiration fields, or even require
 // their presence.
-func NotExpired() Rule {
-	return func(token Token) error {
+var NotBeforeNbf = NotBeforeNbfT[Token]
+
+// NotExpiredT requires that the token has not expired according to the time
+// when this rule is checked and the expiration field of a token. Beware that this
+// rule does not validate the token's issued at or not before fields, or even require
+// their presence.
+func NotExpiredT[T TokenExpiration]() Rule[T] {
+	return func(token T) error {
 		exp, err := token.GetExpiration()
 		if err != nil {
 			return err
@@ -102,9 +154,15 @@ func NotExpired() Rule {
 	}
 }
 
-// Subject requires that the given subject matches the "sub" field of the token.
-func Subject(subject string) Rule {
-	return func(token Token) error {
+// NotExpired requires that the token has not expired according to the time
+// when this rule is checked and the expiration field of a token. Beware that this
+// rule does not validate the token's issued at or not before fields, or even require
+// their presence.
+var NotExpired = NotExpiredT[Token]
+
+// SubjectT requires that the given subject matches the subject field of the token.
+func SubjectT[T TokenSubject](subject string) Rule[T] {
+	return func(token T) error {
 		tSub, err := token.GetSubject()
 		if err != nil {
 			return err
@@ -118,11 +176,20 @@ func Subject(subject string) Rule {
 	}
 }
 
-// ValidAt requires that the token has not expired according to the given time
-// and the "exp" field, and that the given time is both after the token's issued
-// at time "iat", and the token's not before time "nbf".
-func ValidAt(t time.Time) Rule {
-	return func(token Token) error {
+// Subject requires that the given subject matches the subject field of the token.
+var Subject = SubjectT[Token]
+
+type TokenValidAt interface {
+	TokenIssuedAt
+	TokenNotBefore
+	TokenExpiration
+}
+
+// ValidAtT requires that the token has not expired according to the given time
+// and the expiration field, and that the given time is both after the token's issued
+// at time, and the token's not before time.
+func ValidAtT[T TokenValidAt](t time.Time) Rule[T] {
+	return func(token T) error {
 		iat, err := token.GetIssuedAt()
 		if err != nil {
 			return err
@@ -150,6 +217,11 @@ func ValidAt(t time.Time) Rule {
 		return nil
 	}
 }
+
+// ValidAt requires that the token has not expired according to the given time
+// and the expiration field, and that the given time is both after the token's issued
+// at time, and the token's not before time.
+var ValidAt = ValidAtT[Token]
 
 // GetAudience returns the token's "aud" field, or error if not found or not a
 // string.

--- a/claims_test.go
+++ b/claims_test.go
@@ -142,7 +142,7 @@ func DLessThan(x int) func(t CustomToken) error {
 	}
 }
 
-func CustomTokenFromClaimsAndFooter(caf paseto.EncodedTokenParts) (*CustomToken, error) {
+func CustomTokenFromClaimsAndFooter(caf paseto.TokenClaimsAndFooter) (*CustomToken, error) {
 	token := new(CustomToken)
 
 	if err := json.Unmarshal(caf.Claims, token); err != nil {
@@ -154,7 +154,7 @@ func CustomTokenFromClaimsAndFooter(caf paseto.EncodedTokenParts) (*CustomToken,
 	return token, nil
 }
 
-func ClaimsAndFooterFromCustomToken(token CustomToken) paseto.EncodedTokenParts {
+func ClaimsAndFooterFromCustomToken(token CustomToken) paseto.TokenClaimsAndFooter {
 	claims, err := json.Marshal(token)
 	if err != nil {
 		panic("cannot serialise")

--- a/claims_test.go
+++ b/claims_test.go
@@ -142,7 +142,7 @@ func DLessThan(x int) func(t CustomToken) error {
 	}
 }
 
-func CustomTokenFromClaimsAndFooter(caf paseto.ClaimsAndFooter) (*CustomToken, error) {
+func CustomTokenFromClaimsAndFooter(caf paseto.EncodedTokenParts) (*CustomToken, error) {
 	token := new(CustomToken)
 
 	if err := json.Unmarshal(caf.Claims, token); err != nil {
@@ -154,7 +154,7 @@ func CustomTokenFromClaimsAndFooter(caf paseto.ClaimsAndFooter) (*CustomToken, e
 	return token, nil
 }
 
-func ClaimsAndFooterFromCustomToken(token CustomToken) paseto.ClaimsAndFooter {
+func ClaimsAndFooterFromCustomToken(token CustomToken) paseto.EncodedTokenParts {
 	claims, err := json.Marshal(token)
 	if err != nil {
 		panic("cannot serialise")
@@ -175,11 +175,11 @@ func TestAllClaimsPassStruct(t *testing.T) {
 	key := paseto.NewV4SymmetricKey()
 	secretKey := paseto.NewV4AsymmetricSecretKey()
 
-	encoder := paseto.NewEncoder(ClaimsAndFooterFromCustomToken)
+	encodedToken := ClaimsAndFooterFromCustomToken(token)
 
-	encrypted := encoder.V4Encrypt(key, token, nil)
+	encrypted := encodedToken.V4Encrypt(key, nil)
 
-	signed := encoder.V4Sign(secretKey, token, nil)
+	signed := encodedToken.V4Sign(secretKey, nil)
 
 	parser := paseto.NewParserT(CustomTokenFromClaimsAndFooter)
 	parser.AddRule(paseto.ForAudienceT[CustomToken]("audience"))

--- a/claims_test.go
+++ b/claims_test.go
@@ -1,6 +1,8 @@
 package paseto_test
 
 import (
+	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
@@ -105,6 +107,89 @@ func TestAllClaimsPassV4(t *testing.T) {
 
 	_, err := parser.ParseV4Local(key, encrypted, nil)
 	require.NoError(t, err)
+
+	_, err = parser.ParseV4Public(secretKey.Public(), signed, nil)
+	require.NoError(t, err)
+}
+
+type CustomToken struct {
+	A      string
+	B      string
+	C      time.Time
+	D      int
+	Footer string `json:"-"`
+}
+
+func (t CustomToken) GetAudience() (string, error) {
+	return t.A, nil
+}
+
+func (t CustomToken) GetSubject() (string, error) {
+	return t.B, nil
+}
+
+func (t CustomToken) GetExpiration() (time.Time, error) {
+	return t.C, nil
+}
+
+func DLessThan(x int) func(t CustomToken) error {
+	return func(t CustomToken) error {
+		if t.D >= x {
+			return fmt.Errorf("D too large")
+		}
+
+		return nil
+	}
+}
+
+func CustomTokenFromClaimsAndFooter(caf paseto.ClaimsAndFooter) (*CustomToken, error) {
+	token := new(CustomToken)
+
+	if err := json.Unmarshal(caf.Claims, token); err != nil {
+		return nil, err
+	}
+
+	token.Footer = string(caf.Footer)
+
+	return token, nil
+}
+
+func ClaimsAndFooterFromCustomToken(token CustomToken) paseto.ClaimsAndFooter {
+	claims, err := json.Marshal(token)
+	if err != nil {
+		panic("cannot serialise")
+	}
+
+	return paseto.NewClaimsAndFooter(claims, []byte(token.Footer))
+}
+
+func TestAllClaimsPassStruct(t *testing.T) {
+	token := CustomToken{
+		A:      "audience",
+		B:      "subject",
+		C:      time.Now().Add(time.Minute),
+		D:      6,
+		Footer: "footer",
+	}
+
+	key := paseto.NewV4SymmetricKey()
+	secretKey := paseto.NewV4AsymmetricSecretKey()
+
+	encoder := paseto.NewEncoder(ClaimsAndFooterFromCustomToken)
+
+	encrypted := encoder.V4Encrypt(key, token, nil)
+
+	signed := encoder.V4Sign(secretKey, token, nil)
+
+	parser := paseto.NewParserT(CustomTokenFromClaimsAndFooter)
+	parser.AddRule(paseto.ForAudienceT[CustomToken]("audience"))
+	parser.AddRule(paseto.SubjectT[CustomToken]("subject"))
+	parser.AddRule(paseto.NotExpiredT[CustomToken]())
+	parser.AddRule(DLessThan(10))
+
+	t1, err := parser.ParseV4Local(key, encrypted, nil)
+	require.NoError(t, err)
+	require.Equal(t, token.Footer, t1.Footer)
 
 	_, err = parser.ParseV4Public(secretKey.Public(), signed, nil)
 	require.NoError(t, err)

--- a/encoder.go
+++ b/encoder.go
@@ -1,25 +1,13 @@
 package paseto
 
-type TokenEncoder[T any] func(T) ClaimsAndFooter
-
-type Encoder[T any] struct {
-	encode TokenEncoder[T]
-}
-
-func NewEncoder[T any](encode TokenEncoder[T]) Encoder[T] {
-	return Encoder[T]{
-		encode: encode,
-	}
-}
-
 // V2Sign signs the token, using the given key.
-func (e Encoder[T]) V2Sign(key V2AsymmetricSecretKey, token T) string {
-	return v2PublicSign(e.encode(token), key).string()
+func (p EncodedTokenParts) V2Sign(key V2AsymmetricSecretKey) string {
+	return v2PublicSign(p, key).string()
 }
 
 // V2Encrypt signs the token, using the given key.
-func (e Encoder[T]) V2Encrypt(key V2SymmetricKey, token T) string {
-	return v2LocalEncrypt(e.encode(token), key, nil).string()
+func (p EncodedTokenParts) V2Encrypt(key V2SymmetricKey) string {
+	return v2LocalEncrypt(p, key, nil).string()
 }
 
 // V3Sign signs the token, using the given key and implicit bytes. Implicit
@@ -27,8 +15,8 @@ func (e Encoder[T]) V2Encrypt(key V2SymmetricKey, token T) string {
 // the final token.
 // Implicit must be reprovided for successful verification, and can not be
 // recovered.
-func (e Encoder[T]) V3Sign(key V3AsymmetricSecretKey, token T, implicit []byte) string {
-	return v3PublicSign(e.encode(token), key, implicit).string()
+func (p EncodedTokenParts) V3Sign(key V3AsymmetricSecretKey, implicit []byte) string {
+	return v3PublicSign(p, key, implicit).string()
 }
 
 // V3Encrypt signs the token, using the given key and implicit bytes. Implicit
@@ -36,8 +24,8 @@ func (e Encoder[T]) V3Sign(key V3AsymmetricSecretKey, token T, implicit []byte) 
 // present in the final token (or its decrypted value).
 // Implicit must be reprovided for successful decryption, and can not be
 // recovered.
-func (e Encoder[T]) V3Encrypt(key V3SymmetricKey, token T, implicit []byte) string {
-	return v3LocalEncrypt(e.encode(token), key, implicit, nil).string()
+func (p EncodedTokenParts) V3Encrypt(key V3SymmetricKey, implicit []byte) string {
+	return v3LocalEncrypt(p, key, implicit, nil).string()
 }
 
 // V4Sign signs the token, using the given key and implicit bytes. Implicit
@@ -45,8 +33,8 @@ func (e Encoder[T]) V3Encrypt(key V3SymmetricKey, token T, implicit []byte) stri
 // the final token.
 // Implicit must be reprovided for successful verification, and can not be
 // recovered.
-func (e Encoder[T]) V4Sign(key V4AsymmetricSecretKey, token T, implicit []byte) string {
-	return v4PublicSign(e.encode(token), key, implicit).string()
+func (p EncodedTokenParts) V4Sign(key V4AsymmetricSecretKey, implicit []byte) string {
+	return v4PublicSign(p, key, implicit).string()
 }
 
 // V4Encrypt signs the token, using the given key and implicit bytes. Implicit
@@ -54,6 +42,6 @@ func (e Encoder[T]) V4Sign(key V4AsymmetricSecretKey, token T, implicit []byte) 
 // present in the final token (or its decrypted value).
 // Implicit must be reprovided for successful decryption, and can not be
 // recovered.
-func (e Encoder[T]) V4Encrypt(key V4SymmetricKey, token T, implicit []byte) string {
-	return v4LocalEncrypt(e.encode(token), key, implicit, nil).string()
+func (p EncodedTokenParts) V4Encrypt(key V4SymmetricKey, implicit []byte) string {
+	return v4LocalEncrypt(p, key, implicit, nil).string()
 }

--- a/encoder.go
+++ b/encoder.go
@@ -1,0 +1,59 @@
+package paseto
+
+type TokenEncoder[T any] func(T) ClaimsAndFooter
+
+type Encoder[T any] struct {
+	encode TokenEncoder[T]
+}
+
+func NewEncoder[T any](encode TokenEncoder[T]) Encoder[T] {
+	return Encoder[T]{
+		encode: encode,
+	}
+}
+
+// V2Sign signs the token, using the given key.
+func (e Encoder[T]) V2Sign(key V2AsymmetricSecretKey, token T) string {
+	return v2PublicSign(e.encode(token), key).string()
+}
+
+// V2Encrypt signs the token, using the given key.
+func (e Encoder[T]) V2Encrypt(key V2SymmetricKey, token T) string {
+	return v2LocalEncrypt(e.encode(token), key, nil).string()
+}
+
+// V3Sign signs the token, using the given key and implicit bytes. Implicit
+// bytes are bytes used to calculate the signature, but which are not present in
+// the final token.
+// Implicit must be reprovided for successful verification, and can not be
+// recovered.
+func (e Encoder[T]) V3Sign(key V3AsymmetricSecretKey, token T, implicit []byte) string {
+	return v3PublicSign(e.encode(token), key, implicit).string()
+}
+
+// V3Encrypt signs the token, using the given key and implicit bytes. Implicit
+// bytes are bytes used to calculate the encrypted token, but which are not
+// present in the final token (or its decrypted value).
+// Implicit must be reprovided for successful decryption, and can not be
+// recovered.
+func (e Encoder[T]) V3Encrypt(key V3SymmetricKey, token T, implicit []byte) string {
+	return v3LocalEncrypt(e.encode(token), key, implicit, nil).string()
+}
+
+// V4Sign signs the token, using the given key and implicit bytes. Implicit
+// bytes are bytes used to calculate the signature, but which are not present in
+// the final token.
+// Implicit must be reprovided for successful verification, and can not be
+// recovered.
+func (e Encoder[T]) V4Sign(key V4AsymmetricSecretKey, token T, implicit []byte) string {
+	return v4PublicSign(e.encode(token), key, implicit).string()
+}
+
+// V4Encrypt signs the token, using the given key and implicit bytes. Implicit
+// bytes are bytes used to calculate the encrypted token, but which are not
+// present in the final token (or its decrypted value).
+// Implicit must be reprovided for successful decryption, and can not be
+// recovered.
+func (e Encoder[T]) V4Encrypt(key V4SymmetricKey, token T, implicit []byte) string {
+	return v4LocalEncrypt(e.encode(token), key, implicit, nil).string()
+}

--- a/encoder.go
+++ b/encoder.go
@@ -1,12 +1,12 @@
 package paseto
 
 // V2Sign signs the token, using the given key.
-func (p EncodedTokenParts) V2Sign(key V2AsymmetricSecretKey) string {
+func (p TokenClaimsAndFooter) V2Sign(key V2AsymmetricSecretKey) string {
 	return v2PublicSign(p, key).string()
 }
 
 // V2Encrypt signs the token, using the given key.
-func (p EncodedTokenParts) V2Encrypt(key V2SymmetricKey) string {
+func (p TokenClaimsAndFooter) V2Encrypt(key V2SymmetricKey) string {
 	return v2LocalEncrypt(p, key, nil).string()
 }
 
@@ -15,7 +15,7 @@ func (p EncodedTokenParts) V2Encrypt(key V2SymmetricKey) string {
 // the final token.
 // Implicit must be reprovided for successful verification, and can not be
 // recovered.
-func (p EncodedTokenParts) V3Sign(key V3AsymmetricSecretKey, implicit []byte) string {
+func (p TokenClaimsAndFooter) V3Sign(key V3AsymmetricSecretKey, implicit []byte) string {
 	return v3PublicSign(p, key, implicit).string()
 }
 
@@ -24,7 +24,7 @@ func (p EncodedTokenParts) V3Sign(key V3AsymmetricSecretKey, implicit []byte) st
 // present in the final token (or its decrypted value).
 // Implicit must be reprovided for successful decryption, and can not be
 // recovered.
-func (p EncodedTokenParts) V3Encrypt(key V3SymmetricKey, implicit []byte) string {
+func (p TokenClaimsAndFooter) V3Encrypt(key V3SymmetricKey, implicit []byte) string {
 	return v3LocalEncrypt(p, key, implicit, nil).string()
 }
 
@@ -33,7 +33,7 @@ func (p EncodedTokenParts) V3Encrypt(key V3SymmetricKey, implicit []byte) string
 // the final token.
 // Implicit must be reprovided for successful verification, and can not be
 // recovered.
-func (p EncodedTokenParts) V4Sign(key V4AsymmetricSecretKey, implicit []byte) string {
+func (p TokenClaimsAndFooter) V4Sign(key V4AsymmetricSecretKey, implicit []byte) string {
 	return v4PublicSign(p, key, implicit).string()
 }
 
@@ -42,6 +42,6 @@ func (p EncodedTokenParts) V4Sign(key V4AsymmetricSecretKey, implicit []byte) st
 // present in the final token (or its decrypted value).
 // Implicit must be reprovided for successful decryption, and can not be
 // recovered.
-func (p EncodedTokenParts) V4Encrypt(key V4SymmetricKey, implicit []byte) string {
+func (p TokenClaimsAndFooter) V4Encrypt(key V4SymmetricKey, implicit []byte) string {
 	return v4LocalEncrypt(p, key, implicit, nil).string()
 }

--- a/export_internal_test.go
+++ b/export_internal_test.go
@@ -4,10 +4,10 @@ package paseto
 // the purpose of exporting some internal functions, which are used in
 // paseto_test.
 
-type Packet = packet
+type Packet = ClaimsAndFooter
 
 var NewMessage = newMessage
-var NewPacket = newPacket
+var NewPacket = NewClaimsAndFooter
 
 var V2LocalDecrypt = v2LocalDecrypt
 var V2LocalEncrypt = v2LocalEncrypt
@@ -25,13 +25,5 @@ var V4PublicVerify = v4PublicVerify
 var V4PublicSign = v4PublicSign
 
 func (m message) Encoded() string {
-	return m.encoded()
-}
-
-func (p packet) Content() []byte {
-	return p.content
-}
-
-func (p packet) Footer() []byte {
-	return p.footer
+	return m.string()
 }

--- a/export_internal_test.go
+++ b/export_internal_test.go
@@ -4,10 +4,7 @@ package paseto
 // the purpose of exporting some internal functions, which are used in
 // paseto_test.
 
-type Packet = EncodedTokenParts
-
 var NewMessage = newMessage
-var NewPacket = NewClaimsAndFooter
 
 var V2LocalDecrypt = v2LocalDecrypt
 var V2LocalEncrypt = v2LocalEncrypt

--- a/export_internal_test.go
+++ b/export_internal_test.go
@@ -4,7 +4,7 @@ package paseto
 // the purpose of exporting some internal functions, which are used in
 // paseto_test.
 
-type Packet = ClaimsAndFooter
+type Packet = EncodedTokenParts
 
 var NewMessage = newMessage
 var NewPacket = NewClaimsAndFooter

--- a/message.go
+++ b/message.go
@@ -54,7 +54,7 @@ func (m message) unsafeFooter() []byte {
 }
 
 // Encoded returns the string representation of a Paseto message.
-func (m message) encoded() string {
+func (m message) string() string {
 	main := m.header() + encoding.Encode(m.p.bytes())
 
 	if len(m.footer) == 0 {
@@ -102,41 +102,41 @@ func deconstructToken(token string) t.Result[deconstructedToken] {
 // V2Verify will verify a v2 public paseto message. Will return a pointer to
 // the verified token (but not validated with rules) if successful, or error in
 // the event of failure.
-func (m message) v2Verify(key V2AsymmetricPublicKey) t.Result[Token] {
-	return t.Chain[Token](v2PublicVerify(m, key)).AndThen(packet.token)
+func (m message) v2Verify(key V2AsymmetricPublicKey) t.Result[ClaimsAndFooter] {
+	return v2PublicVerify(m, key)
 }
 
 // V2Decrypt will decrypt a v2 local paseto message. Will return a pointer to
 // the decrypted token (but not validated with rules) if successful, or error in
 // the event of failure.
-func (m message) v2Decrypt(key V2SymmetricKey) t.Result[Token] {
-	return t.Chain[Token](v2LocalDecrypt(m, key)).AndThen(packet.token)
+func (m message) v2Decrypt(key V2SymmetricKey) t.Result[ClaimsAndFooter] {
+	return v2LocalDecrypt(m, key)
 }
 
 // V3Verify will verify a v4 public paseto message. Will return a pointer to
 // the verified token (but not validated with rules) if successful, or error in
 // the event of failure.
-func (m message) v3Verify(key V3AsymmetricPublicKey, implicit []byte) t.Result[Token] {
-	return t.Chain[Token](v3PublicVerify(m, key, implicit)).AndThen(packet.token)
+func (m message) v3Verify(key V3AsymmetricPublicKey, implicit []byte) t.Result[ClaimsAndFooter] {
+	return v3PublicVerify(m, key, implicit)
 }
 
 // V3Decrypt will decrypt a v3 local paseto message. Will return a pointer to
 // the decrypted token (but not validated with rules) if successful, or error in
 // the event of failure.
-func (m message) v3Decrypt(key V3SymmetricKey, implicit []byte) t.Result[Token] {
-	return t.Chain[Token](v3LocalDecrypt(m, key, implicit)).AndThen(packet.token)
+func (m message) v3Decrypt(key V3SymmetricKey, implicit []byte) t.Result[ClaimsAndFooter] {
+	return v3LocalDecrypt(m, key, implicit)
 }
 
 // V4Verify will verify a v4 public paseto message. Will return a pointer to
 // the verified token (but not validated with rules) if successful, or error in
 // the event of failure.
-func (m message) v4Verify(key V4AsymmetricPublicKey, implicit []byte) t.Result[Token] {
-	return t.Chain[Token](v4PublicVerify(m, key, implicit)).AndThen(packet.token)
+func (m message) v4Verify(key V4AsymmetricPublicKey, implicit []byte) t.Result[ClaimsAndFooter] {
+	return v4PublicVerify(m, key, implicit)
 }
 
 // V4Decrypt will decrypt a v4 local paseto message. Will return a pointer to
 // the decrypted token (but not validated with rules) if successful, or error in
 // the event of failure.
-func (m message) v4Decrypt(key V4SymmetricKey, implicit []byte) t.Result[Token] {
-	return t.Chain[Token](v4LocalDecrypt(m, key, implicit)).AndThen(packet.token)
+func (m message) v4Decrypt(key V4SymmetricKey, implicit []byte) t.Result[ClaimsAndFooter] {
+	return v4LocalDecrypt(m, key, implicit)
 }

--- a/message.go
+++ b/message.go
@@ -102,41 +102,41 @@ func deconstructToken(token string) t.Result[deconstructedToken] {
 // V2Verify will verify a v2 public paseto message. Will return a pointer to
 // the verified token (but not validated with rules) if successful, or error in
 // the event of failure.
-func (m message) v2Verify(key V2AsymmetricPublicKey) t.Result[EncodedTokenParts] {
+func (m message) v2Verify(key V2AsymmetricPublicKey) t.Result[TokenClaimsAndFooter] {
 	return v2PublicVerify(m, key)
 }
 
 // V2Decrypt will decrypt a v2 local paseto message. Will return a pointer to
 // the decrypted token (but not validated with rules) if successful, or error in
 // the event of failure.
-func (m message) v2Decrypt(key V2SymmetricKey) t.Result[EncodedTokenParts] {
+func (m message) v2Decrypt(key V2SymmetricKey) t.Result[TokenClaimsAndFooter] {
 	return v2LocalDecrypt(m, key)
 }
 
 // V3Verify will verify a v4 public paseto message. Will return a pointer to
 // the verified token (but not validated with rules) if successful, or error in
 // the event of failure.
-func (m message) v3Verify(key V3AsymmetricPublicKey, implicit []byte) t.Result[EncodedTokenParts] {
+func (m message) v3Verify(key V3AsymmetricPublicKey, implicit []byte) t.Result[TokenClaimsAndFooter] {
 	return v3PublicVerify(m, key, implicit)
 }
 
 // V3Decrypt will decrypt a v3 local paseto message. Will return a pointer to
 // the decrypted token (but not validated with rules) if successful, or error in
 // the event of failure.
-func (m message) v3Decrypt(key V3SymmetricKey, implicit []byte) t.Result[EncodedTokenParts] {
+func (m message) v3Decrypt(key V3SymmetricKey, implicit []byte) t.Result[TokenClaimsAndFooter] {
 	return v3LocalDecrypt(m, key, implicit)
 }
 
 // V4Verify will verify a v4 public paseto message. Will return a pointer to
 // the verified token (but not validated with rules) if successful, or error in
 // the event of failure.
-func (m message) v4Verify(key V4AsymmetricPublicKey, implicit []byte) t.Result[EncodedTokenParts] {
+func (m message) v4Verify(key V4AsymmetricPublicKey, implicit []byte) t.Result[TokenClaimsAndFooter] {
 	return v4PublicVerify(m, key, implicit)
 }
 
 // V4Decrypt will decrypt a v4 local paseto message. Will return a pointer to
 // the decrypted token (but not validated with rules) if successful, or error in
 // the event of failure.
-func (m message) v4Decrypt(key V4SymmetricKey, implicit []byte) t.Result[EncodedTokenParts] {
+func (m message) v4Decrypt(key V4SymmetricKey, implicit []byte) t.Result[TokenClaimsAndFooter] {
 	return v4LocalDecrypt(m, key, implicit)
 }

--- a/message.go
+++ b/message.go
@@ -102,41 +102,41 @@ func deconstructToken(token string) t.Result[deconstructedToken] {
 // V2Verify will verify a v2 public paseto message. Will return a pointer to
 // the verified token (but not validated with rules) if successful, or error in
 // the event of failure.
-func (m message) v2Verify(key V2AsymmetricPublicKey) t.Result[ClaimsAndFooter] {
+func (m message) v2Verify(key V2AsymmetricPublicKey) t.Result[EncodedTokenParts] {
 	return v2PublicVerify(m, key)
 }
 
 // V2Decrypt will decrypt a v2 local paseto message. Will return a pointer to
 // the decrypted token (but not validated with rules) if successful, or error in
 // the event of failure.
-func (m message) v2Decrypt(key V2SymmetricKey) t.Result[ClaimsAndFooter] {
+func (m message) v2Decrypt(key V2SymmetricKey) t.Result[EncodedTokenParts] {
 	return v2LocalDecrypt(m, key)
 }
 
 // V3Verify will verify a v4 public paseto message. Will return a pointer to
 // the verified token (but not validated with rules) if successful, or error in
 // the event of failure.
-func (m message) v3Verify(key V3AsymmetricPublicKey, implicit []byte) t.Result[ClaimsAndFooter] {
+func (m message) v3Verify(key V3AsymmetricPublicKey, implicit []byte) t.Result[EncodedTokenParts] {
 	return v3PublicVerify(m, key, implicit)
 }
 
 // V3Decrypt will decrypt a v3 local paseto message. Will return a pointer to
 // the decrypted token (but not validated with rules) if successful, or error in
 // the event of failure.
-func (m message) v3Decrypt(key V3SymmetricKey, implicit []byte) t.Result[ClaimsAndFooter] {
+func (m message) v3Decrypt(key V3SymmetricKey, implicit []byte) t.Result[EncodedTokenParts] {
 	return v3LocalDecrypt(m, key, implicit)
 }
 
 // V4Verify will verify a v4 public paseto message. Will return a pointer to
 // the verified token (but not validated with rules) if successful, or error in
 // the event of failure.
-func (m message) v4Verify(key V4AsymmetricPublicKey, implicit []byte) t.Result[ClaimsAndFooter] {
+func (m message) v4Verify(key V4AsymmetricPublicKey, implicit []byte) t.Result[EncodedTokenParts] {
 	return v4PublicVerify(m, key, implicit)
 }
 
 // V4Decrypt will decrypt a v4 local paseto message. Will return a pointer to
 // the decrypted token (but not validated with rules) if successful, or error in
 // the event of failure.
-func (m message) v4Decrypt(key V4SymmetricKey, implicit []byte) t.Result[ClaimsAndFooter] {
+func (m message) v4Decrypt(key V4SymmetricKey, implicit []byte) t.Result[EncodedTokenParts] {
 	return v4LocalDecrypt(m, key, implicit)
 }

--- a/parser.go
+++ b/parser.go
@@ -6,7 +6,7 @@ import (
 	t "aidanwoods.dev/go-result"
 )
 
-type TokenDecoder[T any] func(EncodedTokenParts) (*T, error)
+type TokenDecoder[T any] func(TokenClaimsAndFooter) (*T, error)
 
 // Parser is used to verify or decrypt a token, and can be provided with
 // a set of rules.
@@ -67,10 +67,10 @@ func MakeParserT[T any](decoder TokenDecoder[T], rules []Rule[T]) Parser[T] {
 // ParseV2Local will parse and decrypt a v2 local paseto and validate against
 // any parser rules. Error if parsing, decryption, or any rule fails.
 func (p Parser[T]) ParseV2Local(key V2SymmetricKey, tainted string) (*T, error) {
-	return t.Chain3[T, T, EncodedTokenParts](
+	return t.Chain3[T, T, TokenClaimsAndFooter](
 		newMessage(V2Local, tainted)).
-		AndThen(func(m message) t.Result[EncodedTokenParts] { return m.v2Decrypt(key) }).
-		AndThen(func(caf EncodedTokenParts) t.Result[T] { return t.NewPtrResult(p.decode(caf)) }).
+		AndThen(func(m message) t.Result[TokenClaimsAndFooter] { return m.v2Decrypt(key) }).
+		AndThen(func(caf TokenClaimsAndFooter) t.Result[T] { return t.NewPtrResult(p.decode(caf)) }).
 		AndThen(p.validate).
 		Results()
 }
@@ -78,10 +78,10 @@ func (p Parser[T]) ParseV2Local(key V2SymmetricKey, tainted string) (*T, error) 
 // ParseV2Public will parse and verify a v2 public paseto and validate against
 // any parser rules. Error if parsing, verification, or any rule fails.
 func (p Parser[T]) ParseV2Public(key V2AsymmetricPublicKey, tainted string) (*T, error) {
-	return t.Chain3[T, T, EncodedTokenParts](
+	return t.Chain3[T, T, TokenClaimsAndFooter](
 		newMessage(V2Public, tainted)).
-		AndThen(func(m message) t.Result[EncodedTokenParts] { return m.v2Verify(key) }).
-		AndThen(func(caf EncodedTokenParts) t.Result[T] { return t.NewPtrResult(p.decode(caf)) }).
+		AndThen(func(m message) t.Result[TokenClaimsAndFooter] { return m.v2Verify(key) }).
+		AndThen(func(caf TokenClaimsAndFooter) t.Result[T] { return t.NewPtrResult(p.decode(caf)) }).
 		AndThen(p.validate).
 		Results()
 }
@@ -89,10 +89,10 @@ func (p Parser[T]) ParseV2Public(key V2AsymmetricPublicKey, tainted string) (*T,
 // ParseV3Local will parse and decrypt a v3 local paseto and validate against
 // any parser rules. Error if parsing, decryption, or any rule fails.
 func (p Parser[T]) ParseV3Local(key V3SymmetricKey, tainted string, implicit []byte) (*T, error) {
-	return t.Chain3[T, T, EncodedTokenParts](
+	return t.Chain3[T, T, TokenClaimsAndFooter](
 		newMessage(V3Local, tainted)).
-		AndThen(func(m message) t.Result[EncodedTokenParts] { return m.v3Decrypt(key, implicit) }).
-		AndThen(func(caf EncodedTokenParts) t.Result[T] { return t.NewPtrResult(p.decode(caf)) }).
+		AndThen(func(m message) t.Result[TokenClaimsAndFooter] { return m.v3Decrypt(key, implicit) }).
+		AndThen(func(caf TokenClaimsAndFooter) t.Result[T] { return t.NewPtrResult(p.decode(caf)) }).
 		AndThen(p.validate).
 		Results()
 }
@@ -100,10 +100,10 @@ func (p Parser[T]) ParseV3Local(key V3SymmetricKey, tainted string, implicit []b
 // ParseV3Public will parse and verify a v3 public paseto and validate against
 // any parser rules. Error if parsing, verification, or any rule fails.
 func (p Parser[T]) ParseV3Public(key V3AsymmetricPublicKey, tainted string, implicit []byte) (*T, error) {
-	return t.Chain3[T, T, EncodedTokenParts](
+	return t.Chain3[T, T, TokenClaimsAndFooter](
 		newMessage(V3Public, tainted)).
-		AndThen(func(m message) t.Result[EncodedTokenParts] { return m.v3Verify(key, implicit) }).
-		AndThen(func(caf EncodedTokenParts) t.Result[T] { return t.NewPtrResult(p.decode(caf)) }).
+		AndThen(func(m message) t.Result[TokenClaimsAndFooter] { return m.v3Verify(key, implicit) }).
+		AndThen(func(caf TokenClaimsAndFooter) t.Result[T] { return t.NewPtrResult(p.decode(caf)) }).
 		AndThen(p.validate).
 		Results()
 }
@@ -111,10 +111,10 @@ func (p Parser[T]) ParseV3Public(key V3AsymmetricPublicKey, tainted string, impl
 // ParseV4Local will parse and decrypt a v4 local paseto and validate against
 // any parser rules. Error if parsing, decryption, or any rule fails.
 func (p Parser[T]) ParseV4Local(key V4SymmetricKey, tainted string, implicit []byte) (*T, error) {
-	return t.Chain3[T, T, EncodedTokenParts](
+	return t.Chain3[T, T, TokenClaimsAndFooter](
 		newMessage(V4Local, tainted)).
-		AndThen(func(m message) t.Result[EncodedTokenParts] { return m.v4Decrypt(key, implicit) }).
-		AndThen(func(caf EncodedTokenParts) t.Result[T] { return t.NewPtrResult(p.decode(caf)) }).
+		AndThen(func(m message) t.Result[TokenClaimsAndFooter] { return m.v4Decrypt(key, implicit) }).
+		AndThen(func(caf TokenClaimsAndFooter) t.Result[T] { return t.NewPtrResult(p.decode(caf)) }).
 		AndThen(p.validate).
 		Results()
 }
@@ -122,10 +122,10 @@ func (p Parser[T]) ParseV4Local(key V4SymmetricKey, tainted string, implicit []b
 // ParseV4Public will parse and verify a v4 public paseto and validate against
 // any parser rules. Error if parsing, verification, or any rule fails.
 func (p Parser[T]) ParseV4Public(key V4AsymmetricPublicKey, tainted string, implicit []byte) (*T, error) {
-	return t.Chain3[T, T, EncodedTokenParts](
+	return t.Chain3[T, T, TokenClaimsAndFooter](
 		newMessage(V4Public, tainted)).
-		AndThen(func(m message) t.Result[EncodedTokenParts] { return m.v4Verify(key, implicit) }).
-		AndThen(func(caf EncodedTokenParts) t.Result[T] { return t.NewPtrResult(p.decode(caf)) }).
+		AndThen(func(m message) t.Result[TokenClaimsAndFooter] { return m.v4Verify(key, implicit) }).
+		AndThen(func(caf TokenClaimsAndFooter) t.Result[T] { return t.NewPtrResult(p.decode(caf)) }).
 		AndThen(p.validate).
 		Results()
 }

--- a/parser.go
+++ b/parser.go
@@ -6,7 +6,7 @@ import (
 	t "aidanwoods.dev/go-result"
 )
 
-type TokenDecoder[T any] func(ClaimsAndFooter) (*T, error)
+type TokenDecoder[T any] func(EncodedTokenParts) (*T, error)
 
 // Parser is used to verify or decrypt a token, and can be provided with
 // a set of rules.
@@ -67,10 +67,10 @@ func MakeParserT[T any](decoder TokenDecoder[T], rules []Rule[T]) Parser[T] {
 // ParseV2Local will parse and decrypt a v2 local paseto and validate against
 // any parser rules. Error if parsing, decryption, or any rule fails.
 func (p Parser[T]) ParseV2Local(key V2SymmetricKey, tainted string) (*T, error) {
-	return t.Chain3[T, T, ClaimsAndFooter](
+	return t.Chain3[T, T, EncodedTokenParts](
 		newMessage(V2Local, tainted)).
-		AndThen(func(m message) t.Result[ClaimsAndFooter] { return m.v2Decrypt(key) }).
-		AndThen(func(caf ClaimsAndFooter) t.Result[T] { return t.NewPtrResult(p.decode(caf)) }).
+		AndThen(func(m message) t.Result[EncodedTokenParts] { return m.v2Decrypt(key) }).
+		AndThen(func(caf EncodedTokenParts) t.Result[T] { return t.NewPtrResult(p.decode(caf)) }).
 		AndThen(p.validate).
 		Results()
 }
@@ -78,10 +78,10 @@ func (p Parser[T]) ParseV2Local(key V2SymmetricKey, tainted string) (*T, error) 
 // ParseV2Public will parse and verify a v2 public paseto and validate against
 // any parser rules. Error if parsing, verification, or any rule fails.
 func (p Parser[T]) ParseV2Public(key V2AsymmetricPublicKey, tainted string) (*T, error) {
-	return t.Chain3[T, T, ClaimsAndFooter](
+	return t.Chain3[T, T, EncodedTokenParts](
 		newMessage(V2Public, tainted)).
-		AndThen(func(m message) t.Result[ClaimsAndFooter] { return m.v2Verify(key) }).
-		AndThen(func(caf ClaimsAndFooter) t.Result[T] { return t.NewPtrResult(p.decode(caf)) }).
+		AndThen(func(m message) t.Result[EncodedTokenParts] { return m.v2Verify(key) }).
+		AndThen(func(caf EncodedTokenParts) t.Result[T] { return t.NewPtrResult(p.decode(caf)) }).
 		AndThen(p.validate).
 		Results()
 }
@@ -89,10 +89,10 @@ func (p Parser[T]) ParseV2Public(key V2AsymmetricPublicKey, tainted string) (*T,
 // ParseV3Local will parse and decrypt a v3 local paseto and validate against
 // any parser rules. Error if parsing, decryption, or any rule fails.
 func (p Parser[T]) ParseV3Local(key V3SymmetricKey, tainted string, implicit []byte) (*T, error) {
-	return t.Chain3[T, T, ClaimsAndFooter](
+	return t.Chain3[T, T, EncodedTokenParts](
 		newMessage(V3Local, tainted)).
-		AndThen(func(m message) t.Result[ClaimsAndFooter] { return m.v3Decrypt(key, implicit) }).
-		AndThen(func(caf ClaimsAndFooter) t.Result[T] { return t.NewPtrResult(p.decode(caf)) }).
+		AndThen(func(m message) t.Result[EncodedTokenParts] { return m.v3Decrypt(key, implicit) }).
+		AndThen(func(caf EncodedTokenParts) t.Result[T] { return t.NewPtrResult(p.decode(caf)) }).
 		AndThen(p.validate).
 		Results()
 }
@@ -100,10 +100,10 @@ func (p Parser[T]) ParseV3Local(key V3SymmetricKey, tainted string, implicit []b
 // ParseV3Public will parse and verify a v3 public paseto and validate against
 // any parser rules. Error if parsing, verification, or any rule fails.
 func (p Parser[T]) ParseV3Public(key V3AsymmetricPublicKey, tainted string, implicit []byte) (*T, error) {
-	return t.Chain3[T, T, ClaimsAndFooter](
+	return t.Chain3[T, T, EncodedTokenParts](
 		newMessage(V3Public, tainted)).
-		AndThen(func(m message) t.Result[ClaimsAndFooter] { return m.v3Verify(key, implicit) }).
-		AndThen(func(caf ClaimsAndFooter) t.Result[T] { return t.NewPtrResult(p.decode(caf)) }).
+		AndThen(func(m message) t.Result[EncodedTokenParts] { return m.v3Verify(key, implicit) }).
+		AndThen(func(caf EncodedTokenParts) t.Result[T] { return t.NewPtrResult(p.decode(caf)) }).
 		AndThen(p.validate).
 		Results()
 }
@@ -111,10 +111,10 @@ func (p Parser[T]) ParseV3Public(key V3AsymmetricPublicKey, tainted string, impl
 // ParseV4Local will parse and decrypt a v4 local paseto and validate against
 // any parser rules. Error if parsing, decryption, or any rule fails.
 func (p Parser[T]) ParseV4Local(key V4SymmetricKey, tainted string, implicit []byte) (*T, error) {
-	return t.Chain3[T, T, ClaimsAndFooter](
+	return t.Chain3[T, T, EncodedTokenParts](
 		newMessage(V4Local, tainted)).
-		AndThen(func(m message) t.Result[ClaimsAndFooter] { return m.v4Decrypt(key, implicit) }).
-		AndThen(func(caf ClaimsAndFooter) t.Result[T] { return t.NewPtrResult(p.decode(caf)) }).
+		AndThen(func(m message) t.Result[EncodedTokenParts] { return m.v4Decrypt(key, implicit) }).
+		AndThen(func(caf EncodedTokenParts) t.Result[T] { return t.NewPtrResult(p.decode(caf)) }).
 		AndThen(p.validate).
 		Results()
 }
@@ -122,10 +122,10 @@ func (p Parser[T]) ParseV4Local(key V4SymmetricKey, tainted string, implicit []b
 // ParseV4Public will parse and verify a v4 public paseto and validate against
 // any parser rules. Error if parsing, verification, or any rule fails.
 func (p Parser[T]) ParseV4Public(key V4AsymmetricPublicKey, tainted string, implicit []byte) (*T, error) {
-	return t.Chain3[T, T, ClaimsAndFooter](
+	return t.Chain3[T, T, EncodedTokenParts](
 		newMessage(V4Public, tainted)).
-		AndThen(func(m message) t.Result[ClaimsAndFooter] { return m.v4Verify(key, implicit) }).
-		AndThen(func(caf ClaimsAndFooter) t.Result[T] { return t.NewPtrResult(p.decode(caf)) }).
+		AndThen(func(m message) t.Result[EncodedTokenParts] { return m.v4Verify(key, implicit) }).
+		AndThen(func(caf EncodedTokenParts) t.Result[T] { return t.NewPtrResult(p.decode(caf)) }).
 		AndThen(p.validate).
 		Results()
 }

--- a/parser.go
+++ b/parser.go
@@ -6,89 +6,126 @@ import (
 	t "aidanwoods.dev/go-result"
 )
 
+type TokenDecoder[T any] func(ClaimsAndFooter) (*T, error)
+
 // Parser is used to verify or decrypt a token, and can be provided with
 // a set of rules.
-type Parser struct {
-	rules []Rule
+type Parser[T any] struct {
+	rules  []Rule[T]
+	decode TokenDecoder[T]
 }
 
 // NewParser returns a parser with NotExpired rule preloaded.
-func NewParser() Parser {
-	return Parser{[]Rule{NotExpired()}}
+func NewParser() Parser[Token] {
+	return Parser[Token]{
+		rules:  []Rule[Token]{NotExpired()},
+		decode: StdDecoder,
+	}
+}
+
+// NewParser returns a parser with NotExpired rule preloaded.
+func NewParserT[T TokenExpiration](decoder TokenDecoder[T]) Parser[T] {
+	return Parser[T]{
+		rules:  []Rule[T]{NotExpiredT[T]()},
+		decode: decoder,
+	}
 }
 
 // NewParserWithoutExpiryCheck returns a parser with no currently set rules.
-func NewParserWithoutExpiryCheck() Parser {
-	return Parser{nil}
+func NewParserWithoutExpiryCheck() Parser[Token] {
+	return Parser[Token]{
+		rules:  []Rule[Token]{},
+		decode: StdDecoder,
+	}
 }
 
 // NewParserForValidNow returns a parser that will require parsed tokens to be
 // valid "now".
-func NewParserForValidNow() Parser {
-	return Parser{[]Rule{ValidAt(time.Now())}}
+func NewParserForValidNow() Parser[Token] {
+	return Parser[Token]{
+		rules:  []Rule[Token]{ValidAt(time.Now())},
+		decode: StdDecoder,
+	}
 }
 
 // MakeParser allows a parser to be constructed with a specified set of rules.
-func MakeParser(rules []Rule) Parser {
-	return Parser{rules}
+func MakeParser(rules []Rule[Token]) Parser[Token] {
+	return Parser[Token]{
+		rules:  rules,
+		decode: StdDecoder,
+	}
+}
+
+// MakeParser allows a parser to be constructed with a specified set of rules.
+func MakeParserT[T any](decoder TokenDecoder[T], rules []Rule[T]) Parser[T] {
+	return Parser[T]{
+		rules:  rules,
+		decode: decoder,
+	}
 }
 
 // ParseV2Local will parse and decrypt a v2 local paseto and validate against
 // any parser rules. Error if parsing, decryption, or any rule fails.
-func (p Parser) ParseV2Local(key V2SymmetricKey, tainted string) (*Token, error) {
-	return t.Chain2[Token, Token](
+func (p Parser[T]) ParseV2Local(key V2SymmetricKey, tainted string) (*T, error) {
+	return t.Chain3[T, T, ClaimsAndFooter](
 		newMessage(V2Local, tainted)).
-		AndThen(func(m message) t.Result[Token] { return m.v2Decrypt(key) }).
+		AndThen(func(m message) t.Result[ClaimsAndFooter] { return m.v2Decrypt(key) }).
+		AndThen(func(caf ClaimsAndFooter) t.Result[T] { return t.NewPtrResult(p.decode(caf)) }).
 		AndThen(p.validate).
 		Results()
 }
 
 // ParseV2Public will parse and verify a v2 public paseto and validate against
 // any parser rules. Error if parsing, verification, or any rule fails.
-func (p Parser) ParseV2Public(key V2AsymmetricPublicKey, tainted string) (*Token, error) {
-	return t.Chain2[Token, Token](
+func (p Parser[T]) ParseV2Public(key V2AsymmetricPublicKey, tainted string) (*T, error) {
+	return t.Chain3[T, T, ClaimsAndFooter](
 		newMessage(V2Public, tainted)).
-		AndThen(func(m message) t.Result[Token] { return m.v2Verify(key) }).
+		AndThen(func(m message) t.Result[ClaimsAndFooter] { return m.v2Verify(key) }).
+		AndThen(func(caf ClaimsAndFooter) t.Result[T] { return t.NewPtrResult(p.decode(caf)) }).
 		AndThen(p.validate).
 		Results()
 }
 
 // ParseV3Local will parse and decrypt a v3 local paseto and validate against
 // any parser rules. Error if parsing, decryption, or any rule fails.
-func (p Parser) ParseV3Local(key V3SymmetricKey, tainted string, implicit []byte) (*Token, error) {
-	return t.Chain2[Token, Token](
+func (p Parser[T]) ParseV3Local(key V3SymmetricKey, tainted string, implicit []byte) (*T, error) {
+	return t.Chain3[T, T, ClaimsAndFooter](
 		newMessage(V3Local, tainted)).
-		AndThen(func(m message) t.Result[Token] { return m.v3Decrypt(key, implicit) }).
+		AndThen(func(m message) t.Result[ClaimsAndFooter] { return m.v3Decrypt(key, implicit) }).
+		AndThen(func(caf ClaimsAndFooter) t.Result[T] { return t.NewPtrResult(p.decode(caf)) }).
 		AndThen(p.validate).
 		Results()
 }
 
 // ParseV3Public will parse and verify a v3 public paseto and validate against
 // any parser rules. Error if parsing, verification, or any rule fails.
-func (p Parser) ParseV3Public(key V3AsymmetricPublicKey, tainted string, implicit []byte) (*Token, error) {
-	return t.Chain2[Token, Token](
+func (p Parser[T]) ParseV3Public(key V3AsymmetricPublicKey, tainted string, implicit []byte) (*T, error) {
+	return t.Chain3[T, T, ClaimsAndFooter](
 		newMessage(V3Public, tainted)).
-		AndThen(func(m message) t.Result[Token] { return m.v3Verify(key, implicit) }).
+		AndThen(func(m message) t.Result[ClaimsAndFooter] { return m.v3Verify(key, implicit) }).
+		AndThen(func(caf ClaimsAndFooter) t.Result[T] { return t.NewPtrResult(p.decode(caf)) }).
 		AndThen(p.validate).
 		Results()
 }
 
 // ParseV4Local will parse and decrypt a v4 local paseto and validate against
 // any parser rules. Error if parsing, decryption, or any rule fails.
-func (p Parser) ParseV4Local(key V4SymmetricKey, tainted string, implicit []byte) (*Token, error) {
-	return t.Chain2[Token, Token](
+func (p Parser[T]) ParseV4Local(key V4SymmetricKey, tainted string, implicit []byte) (*T, error) {
+	return t.Chain3[T, T, ClaimsAndFooter](
 		newMessage(V4Local, tainted)).
-		AndThen(func(m message) t.Result[Token] { return m.v4Decrypt(key, implicit) }).
+		AndThen(func(m message) t.Result[ClaimsAndFooter] { return m.v4Decrypt(key, implicit) }).
+		AndThen(func(caf ClaimsAndFooter) t.Result[T] { return t.NewPtrResult(p.decode(caf)) }).
 		AndThen(p.validate).
 		Results()
 }
 
 // ParseV4Public will parse and verify a v4 public paseto and validate against
 // any parser rules. Error if parsing, verification, or any rule fails.
-func (p Parser) ParseV4Public(key V4AsymmetricPublicKey, tainted string, implicit []byte) (*Token, error) {
-	return t.Chain2[Token, Token](
+func (p Parser[T]) ParseV4Public(key V4AsymmetricPublicKey, tainted string, implicit []byte) (*T, error) {
+	return t.Chain3[T, T, ClaimsAndFooter](
 		newMessage(V4Public, tainted)).
-		AndThen(func(m message) t.Result[Token] { return m.v4Verify(key, implicit) }).
+		AndThen(func(m message) t.Result[ClaimsAndFooter] { return m.v4Verify(key, implicit) }).
+		AndThen(func(caf ClaimsAndFooter) t.Result[T] { return t.NewPtrResult(p.decode(caf)) }).
 		AndThen(p.validate).
 		Results()
 }
@@ -96,7 +133,7 @@ func (p Parser) ParseV4Public(key V4AsymmetricPublicKey, tainted string, implici
 // UnsafeParseFooter returns the footer of a Paseto message. Beware that this
 // footer is not cryptographically verified at this stage, nor are any claims
 // validated.
-func (p Parser) UnsafeParseFooter(protocol Protocol, tainted string) ([]byte, error) {
+func (p Parser[T]) UnsafeParseFooter(protocol Protocol, tainted string) ([]byte, error) {
 	return t.Chain[[]byte](
 		newMessage(protocol, tainted)).
 		Map(message.unsafeFooter).
@@ -104,19 +141,19 @@ func (p Parser) UnsafeParseFooter(protocol Protocol, tainted string) ([]byte, er
 }
 
 // SetRules will overwrite any currently set rules with those specified.
-func (p *Parser) SetRules(rules []Rule) {
+func (p *Parser[T]) SetRules(rules []Rule[T]) {
 	p.rules = rules
 }
 
 // AddRule will add the given rule(s) to any already specified.
-func (p *Parser) AddRule(rule ...Rule) {
+func (p *Parser[T]) AddRule(rule ...Rule[T]) {
 	p.rules = append(p.rules, rule...)
 }
 
-func (p Parser) validate(token Token) t.Result[Token] {
+func (p Parser[T]) validate(token T) t.Result[T] {
 	for _, rule := range p.rules {
 		if err := rule(token); err != nil {
-			return t.Err[Token](newRuleError(err))
+			return t.Err[T](newRuleError(err))
 		}
 	}
 

--- a/paseto.go
+++ b/paseto.go
@@ -164,13 +164,15 @@ func protocolForPayload(payload payload) t.Result[Protocol] {
 	}
 }
 
-type ClaimsAndFooter struct {
+type EncodedTokenParts struct {
+	// Serialised token claims. These claims MUST be serialised JSON.
 	Claims []byte
+	// Serialised token footer. This footer SHOULD be serialised JSON.
 	Footer []byte
 }
 
-func NewClaimsAndFooter(claims []byte, footer []byte) ClaimsAndFooter {
-	return ClaimsAndFooter{
+func NewClaimsAndFooter(claims []byte, footer []byte) EncodedTokenParts {
+	return EncodedTokenParts{
 		Claims: claims,
 		Footer: footer,
 	}

--- a/paseto.go
+++ b/paseto.go
@@ -164,15 +164,14 @@ func protocolForPayload(payload payload) t.Result[Protocol] {
 	}
 }
 
-type packet struct {
-	content []byte
-	footer  []byte
+type ClaimsAndFooter struct {
+	Claims []byte
+	Footer []byte
 }
 
-func newPacket(content []byte, footer []byte) packet {
-	return packet{content, footer}
-}
-
-func (p packet) token() t.Result[Token] {
-	return t.NewPtrResult(NewTokenFromClaimsJSON(p.content, p.footer))
+func NewClaimsAndFooter(claims []byte, footer []byte) ClaimsAndFooter {
+	return ClaimsAndFooter{
+		Claims: claims,
+		Footer: footer,
+	}
 }

--- a/paseto.go
+++ b/paseto.go
@@ -164,15 +164,15 @@ func protocolForPayload(payload payload) t.Result[Protocol] {
 	}
 }
 
-type EncodedTokenParts struct {
+type TokenClaimsAndFooter struct {
 	// Serialised token claims. These claims MUST be serialised JSON.
 	Claims []byte
 	// Serialised token footer. This footer SHOULD be serialised JSON.
 	Footer []byte
 }
 
-func NewClaimsAndFooter(claims []byte, footer []byte) EncodedTokenParts {
-	return EncodedTokenParts{
+func NewClaimsAndFooter(claims []byte, footer []byte) TokenClaimsAndFooter {
+	return TokenClaimsAndFooter{
 		Claims: claims,
 		Footer: footer,
 	}

--- a/paseto.go
+++ b/paseto.go
@@ -171,6 +171,9 @@ type TokenClaimsAndFooter struct {
 	Footer []byte
 }
 
+// NewClaimsAndFooter creates a claims and footer pair from custom encoded data.
+// This should be used to transform a custom type into this pair, which
+// can then be signed or encrypted as a paseto token.
 func NewClaimsAndFooter(claims []byte, footer []byte) TokenClaimsAndFooter {
 	return TokenClaimsAndFooter{
 		Claims: claims,

--- a/test-vectors/v3.json
+++ b/test-vectors/v3.json
@@ -98,7 +98,7 @@
       "secret-key": "20347609607477aca8fbfbc5e6218455f3199669792ef8b466faa87bdc67798144c848dd03661eed5ac62461340cea96",
       "secret-key-pem": "-----BEGIN EC PRIVATE KEY-----\nMIGkAgEBBDAgNHYJYHR3rKj7+8XmIYRV8xmWaXku+LRm+qh73Gd5gUTISN0DZh7t\nWsYkYTQM6pagBwYFK4EEACKhZANiAAT7y3xp7hxgV5vnozQTSHjZxcW/NdVS2rY8\nAUA5ftFM72N9dyCSXERpnqMOcodMcvt8kgcrB8KcKee0HU23E79/s4CvEs8hBfnj\nSUd/gcAm08EjSIz06iWjrNy4NakxR3I=\n-----END EC PRIVATE KEY-----",
       "public-key-pem": "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE+8t8ae4cYFeb56M0E0h42cXFvzXVUtq2\nPAFAOX7RTO9jfXcgklxEaZ6jDnKHTHL7fJIHKwfCnCnntB1NtxO/f7OArxLPIQX5\n40lHf4HAJtPBI0iM9Oolo6zcuDWpMUdy\n-----END PUBLIC KEY-----",
-      "token": "v3.public.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAyMi0wMS0wMVQwMDowMDowMCswMDowMCJ9qqEwwrKHKi5lJ7b9MBKc0G4MGZy0ptUiMv3lAUAaz-JY_zjoqBSIxMxhfAoeNYiSyvfUErj76KOPWm1OeNnBPkTSespeSXDGaDfxeIrl3bRrPEIy7tLwLAIsRzsXkfph",
+      "token": "v3.public.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAyMi0wMS0wMVQwMDowMDowMCswMDowMCJ9vrarT0tBPumLsUh5iJGDDH7sIkPk1fW8Ej6R2j-8jB7rkkCJyEKxcMNPJ5jLurPvZSzRdLb-Ia_Y2YXavY77xbLzJQJkA_zjJeYrd8mWQ24oOpkts1Css3Xa74cz_j3A",
       "payload": "{\"data\":\"this is a signed message\",\"exp\":\"2022-01-01T00:00:00+00:00\"}",
       "footer": "",
       "implicit-assertion": ""
@@ -122,7 +122,7 @@
       "secret-key": "20347609607477aca8fbfbc5e6218455f3199669792ef8b466faa87bdc67798144c848dd03661eed5ac62461340cea96",
       "secret-key-pem": "-----BEGIN EC PRIVATE KEY-----\nMIGkAgEBBDAgNHYJYHR3rKj7+8XmIYRV8xmWaXku+LRm+qh73Gd5gUTISN0DZh7t\nWsYkYTQM6pagBwYFK4EEACKhZANiAAT7y3xp7hxgV5vnozQTSHjZxcW/NdVS2rY8\nAUA5ftFM72N9dyCSXERpnqMOcodMcvt8kgcrB8KcKee0HU23E79/s4CvEs8hBfnj\nSUd/gcAm08EjSIz06iWjrNy4NakxR3I=\n-----END EC PRIVATE KEY-----",
       "public-key-pem": "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE+8t8ae4cYFeb56M0E0h42cXFvzXVUtq2\nPAFAOX7RTO9jfXcgklxEaZ6jDnKHTHL7fJIHKwfCnCnntB1NtxO/f7OArxLPIQX5\n40lHf4HAJtPBI0iM9Oolo6zcuDWpMUdy\n-----END PUBLIC KEY-----",
-      "token": "v3.public.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAyMi0wMS0wMVQwMDowMDowMCswMDowMCJ94SjWIbjmS7715GjLSnHnpJrC9Z-cnwK45dmvnVvCRQDCCKAXaKEopTajX0DKYx1Xqr6gcTdfqscLCAbiB4eOW9jlt-oNqdG8TjsYEi6aloBfTzF1DXff_45tFlnBukEX.eyJraWQiOiJkWWtJU3lseFFlZWNFY0hFTGZ6Rjg4VVpyd2JMb2xOaUNkcHpVSEd3OVVxbiJ9",
+      "token": "v3.public.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAyMi0wMS0wMVQwMDowMDowMCswMDowMCJ9FrkqK6FaB39LisqmPmIHLnu5P8zBTdO_EyWqeworXkGMBChHk-ZZWPt2r7qSYpOqWmvf0oBgf9Elx1TKS4a3YKIcaYddPlu6B9w5LT_b76sCqdVDjE5bH8ZgvZ708c48.eyJraWQiOiJkWWtJU3lseFFlZWNFY0hFTGZ6Rjg4VVpyd2JMb2xOaUNkcHpVSEd3OVVxbiJ9",
       "payload": "{\"data\":\"this is a signed message\",\"exp\":\"2022-01-01T00:00:00+00:00\"}",
       "footer": "{\"kid\":\"dYkISylxQeecEcHELfzF88UZrwbLolNiCdpzUHGw9Uqn\"}",
       "implicit-assertion": "{\"test-vector\":\"3-S-3\"}"

--- a/token.go
+++ b/token.go
@@ -14,7 +14,7 @@ type Token struct {
 	footer []byte
 }
 
-func StdDecoder(caf ClaimsAndFooter) (*Token, error) {
+func StdDecoder(caf EncodedTokenParts) (*Token, error) {
 	return NewTokenFromClaimsJSON(caf.Claims, caf.Footer)
 }
 
@@ -179,18 +179,18 @@ func (t *Token) SetFooter(footer []byte) {
 	t.footer = footer
 }
 
-func (t Token) packet() ClaimsAndFooter {
-	return ClaimsAndFooter{t.ClaimsJSON(), []byte(t.footer)}
+func (t Token) encode() EncodedTokenParts {
+	return EncodedTokenParts{t.ClaimsJSON(), []byte(t.footer)}
 }
 
 // V2Sign signs the token, using the given key.
 func (t Token) V2Sign(key V2AsymmetricSecretKey) string {
-	return v2PublicSign(t.packet(), key).string()
+	return t.encode().V2Sign(key)
 }
 
 // V2Encrypt signs the token, using the given key.
 func (t Token) V2Encrypt(key V2SymmetricKey) string {
-	return v2LocalEncrypt(t.packet(), key, nil).string()
+	return t.encode().V2Encrypt(key)
 }
 
 // V3Sign signs the token, using the given key and implicit bytes. Implicit
@@ -199,7 +199,7 @@ func (t Token) V2Encrypt(key V2SymmetricKey) string {
 // Implicit must be reprovided for successful verification, and can not be
 // recovered.
 func (t Token) V3Sign(key V3AsymmetricSecretKey, implicit []byte) string {
-	return v3PublicSign(t.packet(), key, implicit).string()
+	return t.encode().V3Sign(key, implicit)
 }
 
 // V3Encrypt signs the token, using the given key and implicit bytes. Implicit
@@ -208,7 +208,7 @@ func (t Token) V3Sign(key V3AsymmetricSecretKey, implicit []byte) string {
 // Implicit must be reprovided for successful decryption, and can not be
 // recovered.
 func (t Token) V3Encrypt(key V3SymmetricKey, implicit []byte) string {
-	return v3LocalEncrypt(t.packet(), key, implicit, nil).string()
+	return t.encode().V3Encrypt(key, implicit)
 }
 
 // V4Sign signs the token, using the given key and implicit bytes. Implicit
@@ -217,7 +217,7 @@ func (t Token) V3Encrypt(key V3SymmetricKey, implicit []byte) string {
 // Implicit must be reprovided for successful verification, and can not be
 // recovered.
 func (t Token) V4Sign(key V4AsymmetricSecretKey, implicit []byte) string {
-	return v4PublicSign(t.packet(), key, implicit).string()
+	return t.encode().V4Sign(key, implicit)
 }
 
 // V4Encrypt signs the token, using the given key and implicit bytes. Implicit
@@ -226,7 +226,7 @@ func (t Token) V4Sign(key V4AsymmetricSecretKey, implicit []byte) string {
 // Implicit must be reprovided for successful decryption, and can not be
 // recovered.
 func (t Token) V4Encrypt(key V4SymmetricKey, implicit []byte) string {
-	return v4LocalEncrypt(t.packet(), key, implicit, nil).string()
+	return t.encode().V4Encrypt(key, implicit)
 }
 
 func newTokenValue(bytes []byte) json.RawMessage {

--- a/token.go
+++ b/token.go
@@ -14,6 +14,10 @@ type Token struct {
 	footer []byte
 }
 
+func StdDecoder(caf ClaimsAndFooter) (*Token, error) {
+	return NewTokenFromClaimsJSON(caf.Claims, caf.Footer)
+}
+
 // NewToken returns a token with no claims and no footer.
 func NewToken() Token {
 	return Token{make(map[string]json.RawMessage), nil}
@@ -60,7 +64,7 @@ func NewTokenFromClaimsJSON(claimsData []byte, footer []byte) (*Token, error) {
 // Set sets the key with the specified value. Note that this value needs to
 // be serialisable to JSON using encoding/json.
 // Set will check this and return an error if it is not serialisable.
-func (token *Token) Set(key string, value interface{}) error {
+func (token *Token) Set(key string, value any) error {
 	return t.Chain[any](
 		marshalTokenValue(value)).
 		AndThen(func(value json.RawMessage) t.Result[any] {
@@ -71,9 +75,13 @@ func (token *Token) Set(key string, value interface{}) error {
 		UnwrapErrOr(nil)
 }
 
+func Set[T any](token Token, key string, value T) error {
+	return token.Set(key, value)
+}
+
 // Get gets the given key and writes the value into output (which should be a
 // a pointer), if present by parsing the JSON using encoding/json.
-func (t Token) Get(key string, output interface{}) (err error) {
+func (t Token) Get(key string, output any) (err error) {
 	v, ok := t.claims[key]
 	if !ok {
 		return fmt.Errorf("value for key `%s' not present in claims", key)
@@ -85,6 +93,15 @@ func (t Token) Get(key string, output interface{}) (err error) {
 	}
 
 	return nil
+}
+
+func Get[T any](token Token, key string) t.Result[T] {
+	var out T
+	if err := token.Get(key, &out); err != nil {
+		return t.Err[T](err)
+	}
+
+	return t.Ok(out)
 }
 
 // GetString returns the value for a given key as a string, or error if this
@@ -162,18 +179,18 @@ func (t *Token) SetFooter(footer []byte) {
 	t.footer = footer
 }
 
-func (t Token) packet() packet {
-	return packet{t.ClaimsJSON(), []byte(t.footer)}
+func (t Token) packet() ClaimsAndFooter {
+	return ClaimsAndFooter{t.ClaimsJSON(), []byte(t.footer)}
 }
 
 // V2Sign signs the token, using the given key.
 func (t Token) V2Sign(key V2AsymmetricSecretKey) string {
-	return v2PublicSign(t.packet(), key).encoded()
+	return v2PublicSign(t.packet(), key).string()
 }
 
 // V2Encrypt signs the token, using the given key.
 func (t Token) V2Encrypt(key V2SymmetricKey) string {
-	return v2LocalEncrypt(t.packet(), key, nil).encoded()
+	return v2LocalEncrypt(t.packet(), key, nil).string()
 }
 
 // V3Sign signs the token, using the given key and implicit bytes. Implicit
@@ -182,7 +199,7 @@ func (t Token) V2Encrypt(key V2SymmetricKey) string {
 // Implicit must be reprovided for successful verification, and can not be
 // recovered.
 func (t Token) V3Sign(key V3AsymmetricSecretKey, implicit []byte) string {
-	return v3PublicSign(t.packet(), key, implicit).encoded()
+	return v3PublicSign(t.packet(), key, implicit).string()
 }
 
 // V3Encrypt signs the token, using the given key and implicit bytes. Implicit
@@ -191,7 +208,7 @@ func (t Token) V3Sign(key V3AsymmetricSecretKey, implicit []byte) string {
 // Implicit must be reprovided for successful decryption, and can not be
 // recovered.
 func (t Token) V3Encrypt(key V3SymmetricKey, implicit []byte) string {
-	return v3LocalEncrypt(t.packet(), key, implicit, nil).encoded()
+	return v3LocalEncrypt(t.packet(), key, implicit, nil).string()
 }
 
 // V4Sign signs the token, using the given key and implicit bytes. Implicit
@@ -200,7 +217,7 @@ func (t Token) V3Encrypt(key V3SymmetricKey, implicit []byte) string {
 // Implicit must be reprovided for successful verification, and can not be
 // recovered.
 func (t Token) V4Sign(key V4AsymmetricSecretKey, implicit []byte) string {
-	return v4PublicSign(t.packet(), key, implicit).encoded()
+	return v4PublicSign(t.packet(), key, implicit).string()
 }
 
 // V4Encrypt signs the token, using the given key and implicit bytes. Implicit
@@ -209,7 +226,7 @@ func (t Token) V4Sign(key V4AsymmetricSecretKey, implicit []byte) string {
 // Implicit must be reprovided for successful decryption, and can not be
 // recovered.
 func (t Token) V4Encrypt(key V4SymmetricKey, implicit []byte) string {
-	return v4LocalEncrypt(t.packet(), key, implicit, nil).encoded()
+	return v4LocalEncrypt(t.packet(), key, implicit, nil).string()
 }
 
 func newTokenValue(bytes []byte) json.RawMessage {

--- a/token.go
+++ b/token.go
@@ -75,10 +75,6 @@ func (token *Token) Set(key string, value any) error {
 		UnwrapErrOr(nil)
 }
 
-func Set[T any](token Token, key string, value T) error {
-	return token.Set(key, value)
-}
-
 // Get gets the given key and writes the value into output (which should be a
 // a pointer), if present by parsing the JSON using encoding/json.
 func (t Token) Get(key string, output any) (err error) {

--- a/token.go
+++ b/token.go
@@ -14,7 +14,7 @@ type Token struct {
 	footer []byte
 }
 
-func StdDecoder(caf EncodedTokenParts) (*Token, error) {
+func StdDecoder(caf TokenClaimsAndFooter) (*Token, error) {
 	return NewTokenFromClaimsJSON(caf.Claims, caf.Footer)
 }
 
@@ -179,8 +179,8 @@ func (t *Token) SetFooter(footer []byte) {
 	t.footer = footer
 }
 
-func (t Token) encode() EncodedTokenParts {
-	return EncodedTokenParts{t.ClaimsJSON(), []byte(t.footer)}
+func (t Token) encode() TokenClaimsAndFooter {
+	return TokenClaimsAndFooter{t.ClaimsJSON(), []byte(t.footer)}
 }
 
 // V2Sign signs the token, using the given key.

--- a/v2.go
+++ b/v2.go
@@ -10,8 +10,8 @@ import (
 	"golang.org/x/crypto/chacha20poly1305"
 )
 
-func v2PublicSign(packet packet, key V2AsymmetricSecretKey) message {
-	data, footer := packet.content, packet.footer
+func v2PublicSign(packet ClaimsAndFooter, key V2AsymmetricSecretKey) message {
+	data, footer := packet.Claims, packet.Footer
 	header := []byte(V2Public.Header())
 
 	m2 := encoding.Pae(header, data, footer)
@@ -28,10 +28,10 @@ func v2PublicSign(packet packet, key V2AsymmetricSecretKey) message {
 	return newMessageFromPayloadAndFooter(v2PublicPayload{data, signature}, footer)
 }
 
-func v2PublicVerify(msg message, key V2AsymmetricPublicKey) t.Result[packet] {
+func v2PublicVerify(msg message, key V2AsymmetricPublicKey) t.Result[ClaimsAndFooter] {
 	payload, ok := msg.p.(v2PublicPayload)
 	if msg.header() != V2Public.Header() || !ok {
-		return t.Err[packet](errorMessageHeaderVerify(V2Public, msg.header()))
+		return t.Err[ClaimsAndFooter](errorMessageHeaderVerify(V2Public, msg.header()))
 	}
 
 	header, footer := []byte(msg.header()), msg.footer
@@ -40,35 +40,35 @@ func v2PublicVerify(msg message, key V2AsymmetricPublicKey) t.Result[packet] {
 	m2 := encoding.Pae(header, data, footer)
 
 	if !ed25519.Verify(key.material, m2, payload.signature[:]) {
-		return t.Err[packet](errorBadSignature)
+		return t.Err[ClaimsAndFooter](errorBadSignature)
 	}
 
-	return t.Ok(packet{data, footer})
+	return t.Ok(ClaimsAndFooter{data, footer})
 }
 
-func v2LocalEncrypt(p packet, key V2SymmetricKey, unitTestNonce []byte) message {
+func v2LocalEncrypt(p ClaimsAndFooter, key V2SymmetricKey, unitTestNonce []byte) message {
 	var b [24]byte
 	random.UseProvidedOrFillBytes(unitTestNonce, b[:])
 
 	var nonce [24]byte
-	hashing.GenericHash(p.content, nonce[:], b[:])
+	hashing.GenericHash(p.Claims, nonce[:], b[:])
 
 	cipher := t.NewResult(chacha20poly1305.NewX(key.material[:])).
 		Expect("constructing cipher should not fail")
 
 	header := []byte(V2Local.Header())
 
-	preAuth := encoding.Pae(header, nonce[:], p.footer)
+	preAuth := encoding.Pae(header, nonce[:], p.Footer)
 
-	cipherText := cipher.Seal(nil, nonce[:], p.content, preAuth)
+	cipherText := cipher.Seal(nil, nonce[:], p.Claims, preAuth)
 
-	return newMessageFromPayloadAndFooter(v2LocalPayload{nonce, cipherText}, p.footer)
+	return newMessageFromPayloadAndFooter(v2LocalPayload{nonce, cipherText}, p.Footer)
 }
 
-func v2LocalDecrypt(msg message, key V2SymmetricKey) t.Result[packet] {
+func v2LocalDecrypt(msg message, key V2SymmetricKey) t.Result[ClaimsAndFooter] {
 	payload, ok := msg.p.(v2LocalPayload)
 	if msg.header() != V2Local.Header() || !ok {
-		return t.Err[packet](errorMessageHeaderDecrypt(V2Local, msg.header()))
+		return t.Err[ClaimsAndFooter](errorMessageHeaderDecrypt(V2Local, msg.header()))
 	}
 
 	nonce, cipherText := payload.nonce, payload.cipherText
@@ -82,8 +82,8 @@ func v2LocalDecrypt(msg message, key V2SymmetricKey) t.Result[packet] {
 
 	var plaintext []byte
 	if err := t.NewResult(cipher.Open(nil, nonce[:], cipherText, preAuth)).Ok(&plaintext); err != nil {
-		return t.Err[packet](errorDecrypt(err))
+		return t.Err[ClaimsAndFooter](errorDecrypt(err))
 	}
 
-	return t.Ok(packet{plaintext, msg.footer})
+	return t.Ok(ClaimsAndFooter{plaintext, msg.footer})
 }

--- a/v2.go
+++ b/v2.go
@@ -10,7 +10,7 @@ import (
 	"golang.org/x/crypto/chacha20poly1305"
 )
 
-func v2PublicSign(packet EncodedTokenParts, key V2AsymmetricSecretKey) message {
+func v2PublicSign(packet TokenClaimsAndFooter, key V2AsymmetricSecretKey) message {
 	data, footer := packet.Claims, packet.Footer
 	header := []byte(V2Public.Header())
 
@@ -28,10 +28,10 @@ func v2PublicSign(packet EncodedTokenParts, key V2AsymmetricSecretKey) message {
 	return newMessageFromPayloadAndFooter(v2PublicPayload{data, signature}, footer)
 }
 
-func v2PublicVerify(msg message, key V2AsymmetricPublicKey) t.Result[EncodedTokenParts] {
+func v2PublicVerify(msg message, key V2AsymmetricPublicKey) t.Result[TokenClaimsAndFooter] {
 	payload, ok := msg.p.(v2PublicPayload)
 	if msg.header() != V2Public.Header() || !ok {
-		return t.Err[EncodedTokenParts](errorMessageHeaderVerify(V2Public, msg.header()))
+		return t.Err[TokenClaimsAndFooter](errorMessageHeaderVerify(V2Public, msg.header()))
 	}
 
 	header, footer := []byte(msg.header()), msg.footer
@@ -40,13 +40,13 @@ func v2PublicVerify(msg message, key V2AsymmetricPublicKey) t.Result[EncodedToke
 	m2 := encoding.Pae(header, data, footer)
 
 	if !ed25519.Verify(key.material, m2, payload.signature[:]) {
-		return t.Err[EncodedTokenParts](errorBadSignature)
+		return t.Err[TokenClaimsAndFooter](errorBadSignature)
 	}
 
-	return t.Ok(EncodedTokenParts{data, footer})
+	return t.Ok(TokenClaimsAndFooter{data, footer})
 }
 
-func v2LocalEncrypt(p EncodedTokenParts, key V2SymmetricKey, unitTestNonce []byte) message {
+func v2LocalEncrypt(p TokenClaimsAndFooter, key V2SymmetricKey, unitTestNonce []byte) message {
 	var b [24]byte
 	random.UseProvidedOrFillBytes(unitTestNonce, b[:])
 
@@ -65,10 +65,10 @@ func v2LocalEncrypt(p EncodedTokenParts, key V2SymmetricKey, unitTestNonce []byt
 	return newMessageFromPayloadAndFooter(v2LocalPayload{nonce, cipherText}, p.Footer)
 }
 
-func v2LocalDecrypt(msg message, key V2SymmetricKey) t.Result[EncodedTokenParts] {
+func v2LocalDecrypt(msg message, key V2SymmetricKey) t.Result[TokenClaimsAndFooter] {
 	payload, ok := msg.p.(v2LocalPayload)
 	if msg.header() != V2Local.Header() || !ok {
-		return t.Err[EncodedTokenParts](errorMessageHeaderDecrypt(V2Local, msg.header()))
+		return t.Err[TokenClaimsAndFooter](errorMessageHeaderDecrypt(V2Local, msg.header()))
 	}
 
 	nonce, cipherText := payload.nonce, payload.cipherText
@@ -82,8 +82,8 @@ func v2LocalDecrypt(msg message, key V2SymmetricKey) t.Result[EncodedTokenParts]
 
 	var plaintext []byte
 	if err := t.NewResult(cipher.Open(nil, nonce[:], cipherText, preAuth)).Ok(&plaintext); err != nil {
-		return t.Err[EncodedTokenParts](errorDecrypt(err))
+		return t.Err[TokenClaimsAndFooter](errorDecrypt(err))
 	}
 
-	return t.Ok(EncodedTokenParts{plaintext, msg.footer})
+	return t.Ok(TokenClaimsAndFooter{plaintext, msg.footer})
 }

--- a/v3.go
+++ b/v3.go
@@ -14,7 +14,7 @@ import (
 	t "aidanwoods.dev/go-result"
 )
 
-func v3PublicSign(packet EncodedTokenParts, key V3AsymmetricSecretKey, implicit []byte) message {
+func v3PublicSign(packet TokenClaimsAndFooter, key V3AsymmetricSecretKey, implicit []byte) message {
 	data, footer := packet.Claims, packet.Footer
 	header := []byte(V3Public.Header())
 
@@ -44,10 +44,10 @@ func v3PublicSign(packet EncodedTokenParts, key V3AsymmetricSecretKey, implicit 
 	return newMessageFromPayloadAndFooter(v3PublicPayload{data, signature}, footer)
 }
 
-func v3PublicVerify(msg message, key V3AsymmetricPublicKey, implicit []byte) t.Result[EncodedTokenParts] {
+func v3PublicVerify(msg message, key V3AsymmetricPublicKey, implicit []byte) t.Result[TokenClaimsAndFooter] {
 	payload, ok := msg.p.(v3PublicPayload)
 	if msg.header() != V3Public.Header() || !ok {
-		return t.Err[EncodedTokenParts](errorMessageHeaderVerify(V3Public, msg.header()))
+		return t.Err[TokenClaimsAndFooter](errorMessageHeaderVerify(V3Public, msg.header()))
 	}
 
 	header, footer := []byte(msg.header()), msg.footer
@@ -61,13 +61,13 @@ func v3PublicVerify(msg message, key V3AsymmetricPublicKey, implicit []byte) t.R
 	s := new(big.Int).SetBytes(payload.signature[48:])
 
 	if !ecdsa.Verify(&key.material, hash[:], r, s) {
-		return t.Err[EncodedTokenParts](errorBadSignature)
+		return t.Err[TokenClaimsAndFooter](errorBadSignature)
 	}
 
-	return t.Ok(EncodedTokenParts{data, footer})
+	return t.Ok(TokenClaimsAndFooter{data, footer})
 }
 
-func v3LocalEncrypt(p EncodedTokenParts, key V3SymmetricKey, implicit []byte, unitTestNonce []byte) message {
+func v3LocalEncrypt(p TokenClaimsAndFooter, key V3SymmetricKey, implicit []byte, unitTestNonce []byte) message {
 	var nonce [32]byte
 	random.UseProvidedOrFillBytes(unitTestNonce, nonce[:])
 
@@ -92,10 +92,10 @@ func v3LocalEncrypt(p EncodedTokenParts, key V3SymmetricKey, implicit []byte, un
 	return newMessageFromPayloadAndFooter(v3LocalPayload{nonce, cipherText, tag}, p.Footer)
 }
 
-func v3LocalDecrypt(msg message, key V3SymmetricKey, implicit []byte) t.Result[EncodedTokenParts] {
+func v3LocalDecrypt(msg message, key V3SymmetricKey, implicit []byte) t.Result[TokenClaimsAndFooter] {
 	payload, ok := msg.p.(v3LocalPayload)
 	if msg.header() != V3Local.Header() || !ok {
-		return t.Err[EncodedTokenParts](errorMessageHeaderDecrypt(V3Local, msg.header()))
+		return t.Err[TokenClaimsAndFooter](errorMessageHeaderDecrypt(V3Local, msg.header()))
 	}
 
 	nonce, cipherText, givenTag := payload.nonce, payload.cipherText, payload.tag
@@ -112,7 +112,7 @@ func v3LocalDecrypt(msg message, key V3SymmetricKey, implicit []byte) t.Result[E
 	copy(expectedTag[:], hm.Sum(nil))
 
 	if !hmac.Equal(expectedTag[:], givenTag[:]) {
-		return t.Err[EncodedTokenParts](errorBadMAC)
+		return t.Err[TokenClaimsAndFooter](errorBadMAC)
 	}
 
 	blockCipher := t.NewResult(aes.NewCipher(encKey[:])).
@@ -121,5 +121,5 @@ func v3LocalDecrypt(msg message, key V3SymmetricKey, implicit []byte) t.Result[E
 	plainText := make([]byte, len(cipherText))
 	cipher.NewCTR(blockCipher, nonce2[:]).XORKeyStream(plainText, cipherText)
 
-	return t.Ok(EncodedTokenParts{plainText, msg.footer})
+	return t.Ok(TokenClaimsAndFooter{plainText, msg.footer})
 }

--- a/v4.go
+++ b/v4.go
@@ -11,7 +11,7 @@ import (
 	"golang.org/x/crypto/chacha20"
 )
 
-func v4PublicSign(packet ClaimsAndFooter, key V4AsymmetricSecretKey, implicit []byte) message {
+func v4PublicSign(packet EncodedTokenParts, key V4AsymmetricSecretKey, implicit []byte) message {
 	data, footer := packet.Claims, packet.Footer
 	header := []byte(V4Public.Header())
 
@@ -28,10 +28,10 @@ func v4PublicSign(packet ClaimsAndFooter, key V4AsymmetricSecretKey, implicit []
 	return newMessageFromPayloadAndFooter(v4PublicPayload{data, signature}, footer)
 }
 
-func v4PublicVerify(msg message, key V4AsymmetricPublicKey, implicit []byte) t.Result[ClaimsAndFooter] {
+func v4PublicVerify(msg message, key V4AsymmetricPublicKey, implicit []byte) t.Result[EncodedTokenParts] {
 	payload, ok := msg.p.(v4PublicPayload)
 	if msg.header() != V4Public.Header() || !ok {
-		return t.Err[ClaimsAndFooter](errorMessageHeaderVerify(V4Public, msg.header()))
+		return t.Err[EncodedTokenParts](errorMessageHeaderVerify(V4Public, msg.header()))
 	}
 
 	header, footer := []byte(msg.header()), msg.footer
@@ -40,13 +40,13 @@ func v4PublicVerify(msg message, key V4AsymmetricPublicKey, implicit []byte) t.R
 	m2 := encoding.Pae(header, data, footer, implicit)
 
 	if !ed25519.Verify(key.material, m2, payload.signature[:]) {
-		return t.Err[ClaimsAndFooter](errorBadSignature)
+		return t.Err[EncodedTokenParts](errorBadSignature)
 	}
 
-	return t.Ok(ClaimsAndFooter{data, footer})
+	return t.Ok(EncodedTokenParts{data, footer})
 }
 
-func v4LocalEncrypt(p ClaimsAndFooter, key V4SymmetricKey, implicit []byte, unitTestNonce []byte) message {
+func v4LocalEncrypt(p EncodedTokenParts, key V4SymmetricKey, implicit []byte, unitTestNonce []byte) message {
 	var nonce [32]byte
 	random.UseProvidedOrFillBytes(unitTestNonce, nonce[:])
 
@@ -68,10 +68,10 @@ func v4LocalEncrypt(p ClaimsAndFooter, key V4SymmetricKey, implicit []byte, unit
 	return newMessageFromPayloadAndFooter(v4LocalPayload{nonce, cipherText, tag}, p.Footer)
 }
 
-func v4LocalDecrypt(msg message, key V4SymmetricKey, implicit []byte) t.Result[ClaimsAndFooter] {
+func v4LocalDecrypt(msg message, key V4SymmetricKey, implicit []byte) t.Result[EncodedTokenParts] {
 	payload, ok := msg.p.(v4LocalPayload)
 	if msg.header() != V4Local.Header() || !ok {
-		return t.Err[ClaimsAndFooter](errorMessageHeaderDecrypt(V4Local, msg.header()))
+		return t.Err[EncodedTokenParts](errorMessageHeaderDecrypt(V4Local, msg.header()))
 	}
 
 	nonce, cipherText, givenTag := payload.nonce, payload.cipherText, payload.tag
@@ -85,7 +85,7 @@ func v4LocalDecrypt(msg message, key V4SymmetricKey, implicit []byte) t.Result[C
 	hashing.GenericHash(preAuth, expectedTag[:], authKey[:])
 
 	if !hmac.Equal(expectedTag[:], givenTag[:]) {
-		return t.Err[ClaimsAndFooter](errorBadMAC)
+		return t.Err[EncodedTokenParts](errorBadMAC)
 	}
 
 	cipher := t.NewResult(chacha20.NewUnauthenticatedCipher(encKey[:], nonce2[:])).
@@ -94,5 +94,5 @@ func v4LocalDecrypt(msg message, key V4SymmetricKey, implicit []byte) t.Result[C
 	plainText := make([]byte, len(cipherText))
 	cipher.XORKeyStream(plainText, cipherText)
 
-	return t.Ok(ClaimsAndFooter{plainText, msg.footer})
+	return t.Ok(EncodedTokenParts{plainText, msg.footer})
 }

--- a/vectors_test.go
+++ b/vectors_test.go
@@ -90,8 +90,8 @@ func TestV2(t *testing.T) {
 				decoded.Expect("decoded should be present")
 			}
 
-			require.Equal(t, test.Payload, string(decoded.Unwrap().Content()))
-			require.Equal(t, test.Footer, string(decoded.Unwrap().Footer()))
+			require.Equal(t, test.Payload, string(decoded.Unwrap().Claims))
+			require.Equal(t, test.Footer, string(decoded.Unwrap().Footer))
 
 			packet := paseto.NewPacket([]byte(test.Payload), []byte(test.Footer))
 
@@ -183,8 +183,8 @@ func TestV3(t *testing.T) {
 				decoded.Expect("decoded should be present")
 			}
 
-			require.Equal(t, test.Payload, string(decoded.Unwrap().Content()))
-			require.Equal(t, test.Footer, string(decoded.Unwrap().Footer()))
+			require.Equal(t, test.Payload, string(decoded.Unwrap().Claims))
+			require.Equal(t, test.Footer, string(decoded.Unwrap().Footer))
 
 			packet := paseto.NewPacket([]byte(test.Payload), []byte(test.Footer))
 			implicit := []byte(test.ImplicitAssertation)
@@ -218,8 +218,8 @@ func TestV3(t *testing.T) {
 				decoded = paseto.V3PublicVerify(signed, pk, []byte(test.ImplicitAssertation))
 				require.NoError(t, err)
 
-				require.Equal(t, test.Payload, string(decoded.Unwrap().Content()))
-				require.Equal(t, test.Footer, string(decoded.Unwrap().Footer()))
+				require.Equal(t, test.Payload, string(decoded.Unwrap().Claims))
+				require.Equal(t, test.Footer, string(decoded.Unwrap().Footer))
 			}
 		})
 	}
@@ -292,8 +292,8 @@ func TestV4(t *testing.T) {
 				decoded.Expect("decoded should be present")
 			}
 
-			require.Equal(t, test.Payload, string(decoded.Unwrap().Content()))
-			require.Equal(t, test.Footer, string(decoded.Unwrap().Footer()))
+			require.Equal(t, test.Payload, string(decoded.Unwrap().Claims))
+			require.Equal(t, test.Footer, string(decoded.Unwrap().Footer))
 
 			packet := paseto.NewPacket([]byte(test.Payload), []byte(test.Footer))
 			implicit := []byte(test.ImplicitAssertation)

--- a/vectors_test.go
+++ b/vectors_test.go
@@ -40,7 +40,7 @@ func TestV2(t *testing.T) {
 
 	for _, test := range tests.Tests {
 		t.Run(test.Name, func(t *testing.T) {
-			var decoded ty.Result[paseto.Packet]
+			var decoded ty.Result[paseto.TokenClaimsAndFooter]
 
 			switch test.Key {
 			// Local mode
@@ -93,7 +93,7 @@ func TestV2(t *testing.T) {
 			require.Equal(t, test.Payload, string(decoded.Unwrap().Claims))
 			require.Equal(t, test.Footer, string(decoded.Unwrap().Footer))
 
-			packet := paseto.NewPacket([]byte(test.Payload), []byte(test.Footer))
+			packet := paseto.NewClaimsAndFooter([]byte(test.Payload), []byte(test.Footer))
 
 			switch test.Key {
 			// Local mode
@@ -133,7 +133,7 @@ func TestV3(t *testing.T) {
 
 	for _, test := range tests.Tests {
 		t.Run(test.Name, func(t *testing.T) {
-			var decoded ty.Result[paseto.Packet]
+			var decoded ty.Result[paseto.TokenClaimsAndFooter]
 
 			switch test.Key {
 			// Local mode
@@ -186,7 +186,7 @@ func TestV3(t *testing.T) {
 			require.Equal(t, test.Payload, string(decoded.Unwrap().Claims))
 			require.Equal(t, test.Footer, string(decoded.Unwrap().Footer))
 
-			packet := paseto.NewPacket([]byte(test.Payload), []byte(test.Footer))
+			packet := paseto.NewClaimsAndFooter([]byte(test.Payload), []byte(test.Footer))
 			implicit := []byte(test.ImplicitAssertation)
 
 			switch test.Key {
@@ -241,7 +241,7 @@ func TestV4(t *testing.T) {
 
 	for _, test := range tests.Tests {
 		t.Run(test.Name, func(t *testing.T) {
-			var decoded ty.Result[paseto.Packet]
+			var decoded ty.Result[paseto.TokenClaimsAndFooter]
 
 			switch test.Key {
 			// Local mode
@@ -295,7 +295,7 @@ func TestV4(t *testing.T) {
 			require.Equal(t, test.Payload, string(decoded.Unwrap().Claims))
 			require.Equal(t, test.Footer, string(decoded.Unwrap().Footer))
 
-			packet := paseto.NewPacket([]byte(test.Payload), []byte(test.Footer))
+			packet := paseto.NewClaimsAndFooter([]byte(test.Payload), []byte(test.Footer))
 			implicit := []byte(test.ImplicitAssertation)
 
 			switch test.Key {


### PR DESCRIPTION
Adds support for converting custom structs into PASETO tokens, without needing to manually copy claims over one by one.

This change also permits a PASETO token to be parsed into a custom type, where the type system can be take advantage of to interface with claims.