### PR TITLE
No longer force unwrap footer result

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module aidanwoods.dev/go-paseto
 go 1.18
 
 require (
-	aidanwoods.dev/go-result v0.0.0-20230310133209-26c34aabd0c7
+	aidanwoods.dev/go-result v0.0.0-20230617093509-2c57d7732f54
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/crypto v0.7.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-aidanwoods.dev/go-result v0.0.0-20230310133209-26c34aabd0c7 h1:bVUDSxup1h+a2DenqxeTWRschTdSMmo1Cy5/LxnzCtc=
-aidanwoods.dev/go-result v0.0.0-20230310133209-26c34aabd0c7/go.mod h1:yridkWghM7AXSFA6wzx0IbsurIm1Lhuro3rYef8FBHM=
+aidanwoods.dev/go-result v0.0.0-20230617093509-2c57d7732f54 h1:D4xKM5zeP8OHMy8il4nwMssVBr9k3fM3iKeGH0lNIgw=
+aidanwoods.dev/go-result v0.0.0-20230617093509-2c57d7732f54/go.mod h1:yridkWghM7AXSFA6wzx0IbsurIm1Lhuro3rYef8FBHM=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/parser.go
+++ b/parser.go
@@ -96,13 +96,11 @@ func (p Parser) ParseV4Public(key V4AsymmetricPublicKey, tainted string, implici
 // UnsafeParseFooter returns the footer of a Paseto message. Beware that this
 // footer is not cryptographically verified at this stage, nor are any claims
 // validated.
-func (p Parser) UnsafeParseFooter(protocol Protocol, tainted string) (footer []byte, err error) {
-	err = t.Chain[[]byte](
+func (p Parser) UnsafeParseFooter(protocol Protocol, tainted string) ([]byte, error) {
+	return t.Chain[[]byte](
 		newMessage(protocol, tainted)).
 		Map(message.unsafeFooter).
-		Ok(&footer)
-
-	return footer, err
+		ResultsMappingEmpty()
 }
 
 // SetRules will overwrite any currently set rules with those specified.

--- a/parser.go
+++ b/parser.go
@@ -96,11 +96,13 @@ func (p Parser) ParseV4Public(key V4AsymmetricPublicKey, tainted string, implici
 // UnsafeParseFooter returns the footer of a Paseto message. Beware that this
 // footer is not cryptographically verified at this stage, nor are any claims
 // validated.
-func (p Parser) UnsafeParseFooter(protocol Protocol, tainted string) ([]byte, error) {
-	return t.Chain[[]byte](
+func (p Parser) UnsafeParseFooter(protocol Protocol, tainted string) (footer []byte, err error) {
+	err = t.Chain[[]byte](
 		newMessage(protocol, tainted)).
 		Map(message.unsafeFooter).
-		UnwrappedResults()
+		Ok(&footer)
+
+	return footer, err
 }
 
 // SetRules will overwrite any currently set rules with those specified.

--- a/parser_test.go
+++ b/parser_test.go
@@ -1,0 +1,17 @@
+package paseto_test
+
+import (
+	"testing"
+
+	"aidanwoods.dev/go-paseto"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnwrapEmptyFooter(t *testing.T) {
+	token := "v4.local.aGVsbG8gd29ybGQgaGVsbG8gd29ybGQgaGVsbG8gd29ybGQgaGVsbG8gd29ybGQgaGVsbG8gd29ybGQgaGVsbG8gd29ybGQ."
+
+	parser := paseto.NewParser()
+	footer, err := parser.UnsafeParseFooter(paseto.V4Local, token)
+	require.NoError(t, err)
+	require.Empty(t, footer)
+}


### PR DESCRIPTION
Avoid force unwrapping here. I ended up using `UnwrappedResults()` erroneously to match the existing signature `([]byte, error)` over `Results()` which would more safely return `(*[]byte, error)`. The existing signature is the way it is because `[]byte` can have a `nil` state, which isn't expressible at a generic level.

Add some special casing to transform the `Option[[]byte]`  into `[]byte` by mapping the `None` case to `nil == []byte{}`.