### PR TITLE
Added TokenSigner interface to allow external sign algorithm to be used

### DIFF
--- a/token.go
+++ b/token.go
@@ -6,6 +6,10 @@ import (
 	"time"
 )
 
+type TokenSigner interface {
+	SignToken(data []byte) ([]byte, error)
+}
+
 // Token is a set of paseto claims, and a footer
 type Token struct {
 	claims map[string]json.RawMessage
@@ -210,4 +214,21 @@ func (t Token) V4Sign(key V4AsymmetricSecretKey, implicit []byte) string {
 // recovered.
 func (t Token) V4Encrypt(key V4SymmetricKey, implicit []byte) string {
 	return v4LocalEncrypt(t.packet(), key, implicit, nil).encoded()
+}
+
+// V4SignWith signs the token, using the given token signer and implicit bytes. Implicit
+// bytes are bytes used to calculate the signature, but which are not present in
+// the final token.
+// Implicit must be reprovided for successful verification, and can not be
+// recovered.
+func (t Token) V4SignWith(signer TokenSigner, implicit []byte) (string, error) {
+	if signer == nil {
+		panic("signer must not be nil")
+	}
+
+	sig, err := v4PublicSignWith(t.packet(), implicit, signer)
+	if err != nil {
+		return "", err
+	}
+	return sig.encoded(), nil
 }

--- a/v4.go
+++ b/v4.go
@@ -3,6 +3,7 @@ package paseto
 import (
 	"crypto/ed25519"
 	"crypto/hmac"
+	"errors"
 
 	"aidanwoods.dev/go-paseto/internal/encoding"
 	"aidanwoods.dev/go-paseto/internal/hashing"
@@ -99,4 +100,24 @@ func v4LocalDecrypt(msg message, key V4SymmetricKey, implicit []byte) result.Res
 	cipher.XORKeyStream(plainText, cipherText)
 
 	return result.Ok(packet{plainText, msg.footer})
+}
+
+func v4PublicSignWith(packet packet, implicit []byte, signer TokenSigner) (message, error) {
+	data, footer := packet.content, packet.footer
+	header := []byte(V4Public.Header())
+
+	m2 := encoding.Pae(header, data, footer, implicit)
+
+	sig, err := signer.SignToken(m2)
+	if err != nil {
+		return message{}, err
+	}
+	if len(sig) != 64 {
+		return message{}, errors.New("bad signature length")
+	}
+
+	var signature [64]byte
+	copy(signature[:], sig)
+
+	return newMessageFromPayloadAndFooter(v4PublicPayload{data, signature}, footer), nil
 }


### PR DESCRIPTION
Hello,

I am using this library to sign Paseto tokens, but I wanted to use Google KMS to handle the key signature.  
As GCP KMS does not allow reading the private key but only allows sending the payload to sign, I had to modify slightly the library to let the user provide a TokenSigner which will handle the signing instead of using `ed25519.Sign` directly.

The modification is small, but I have only implemented the function for V4 tokens.
I am open to expand the implementation to older versions, as well as adapting the naming to something more sensible, if needed.